### PR TITLE
Fixed typo of mkr wrap option

### DIFF
--- a/content/docs/entry/howto/mkr/wrap.md
+++ b/content/docs/entry/howto/mkr/wrap.md
@@ -75,7 +75,7 @@ If there are previously reported alerts when a succeeding batch job of the same 
 
 This option saves the result in a temporary area and reads it at the next execution, so be sure to use it in an environment with persistent disk space.
 
-### `-I, --notifictation-interval` - Specify the notification retransmission interval
+### `-I, --notification-interval` - Specify the notification retransmission interval
 
 By default, notifications are only sent when an alert occurs or when the status of an alert changes, but you can have notifications sent at fixed intervals for open alerts using this option.
 

--- a/content/ja/docs/entry/howto/mkr/wrap.md
+++ b/content/ja/docs/entry/howto/mkr/wrap.md
@@ -75,7 +75,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-docs-ja.hatenablog.mack
 
 このオプションの挙動は一時領域に結果を保存し、次回実行時にそれを読み出す形となるため、永続的なディスク領域がある環境で利用してください。
 
-### `-I, --notifictation-interval` - 通知再送間隔を指定する
+### `-I, --notification-interval` - 通知再送間隔を指定する
 
 デフォルトではアラート発生時もしくはアラート状態変更時にのみしか通知がおこなわれませんが、このオプションを使うことで発生中のアラートの通知を定期的に送信できます。
 


### PR DESCRIPTION
# What

Hi, I found typo of `mkr wrap` option.

`--notification-interval` is correct, and fixed it 👍 

>Incorrect Usage: flag provided but not defined: -notifictation-interval