### PR TITLE
Improve the English for the Alerts API documentation page / Adjust the example responses for both English&Japanese docs

### DIFF
--- a/content/api-docs/entry/alerts.md
+++ b/content/api-docs/entry/alerts.md
@@ -101,7 +101,7 @@ The designated alert will be closed.
 
 ### Input
 
-```javascript
+```json
 {
   "reason": "<text>"
 }
@@ -115,7 +115,7 @@ Any text can be appended in the `reason` field. This field is a required item.
 
 A post-update alert will be returned.
 
-```javascript
+```json
 {
   "id": "<alertId>",
   "status": "OK",

--- a/content/api-docs/entry/alerts.md
+++ b/content/api-docs/entry/alerts.md
@@ -13,14 +13,14 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 
 <h2 id="get">Getting Alerts</h2>
 
-This will get a list of the alerts.
+This will get the list of alerts.
 
 <p class="type-get">
   <code>GET</code>
   <code>/api/v0/alerts</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -34,7 +34,7 @@ If `nextId` is not specified, alerts will be returned in order of latest occurre
 | PARAM     | TYPE   | DESCRIPTION |
 | -------- | ------ | ----------- |
 | `withClosed` | *boolean* | [optional] Whether or not to get resolved alerts. If true, resolved alerts as well as open alerts are retrieved. |
-| `nextId` | *string* | [optional] If `nextId` is specified, alerts older than the id of the specified alert are retrieved. |
+| `nextId` | *string* | [optional] If `nextId` is specified, alerts older than the alert with the specified id are retrieved. |
 | `limit` | *number* | [optional] The maximum number of alerts to retrieve. When omitted, up to 100 cases are retrieved. The most that can be specified is 100. |
 
 
@@ -47,22 +47,22 @@ If `nextId` is not specified, alerts will be returned in order of latest occurre
 }
 ```
 
-Alerts will be in chronological order of when they were generated from newest to oldest. `nextId` is retrieved when there are more alerts.
+Alerts will be returned in chronological order of when they were generated from newest to oldest. The `nextId` field is returned only when there are more alerts existing.
 
 `<alert>`: an object that holds the following keys.
 
 | KEY      | TYPE            | DESCRIPTION                                       |
 | -------- | ------          | -----------                                       |
-| `id`     | *string*        | alert's ID                                      |
-| `status` | *string*        | alert's current status: `"OK"`, `"CRITICAL"`, `"WARNING"`, or `"UNKNOWN"` |
-| `monitorId`  | *string* | ID of the monitor that generated the alert |
-| `type`  | *string* | the type of monitor: connectivity (`"connectivity"`), host metric (`"host"`), service metric (`"service"`), external monitor (`"external"`), check monitor (`"check"`), expression monitor (`"expression"`), or anomaly detection for roles (`"anomalyDetection"`) |
-| `hostId`  | *string* | [optional] the associated host ID. only exists when the type of monitor is either `"connectivity"`, `"host"`, `"check"`, or `"anomalyDetection"` |
-| `value`  | *number* | [optional] value of the monitoring target. only exists when the type of monitor is `"host"`, or `"service"` or when there is a reponse time configuration in `"external"` |
-| `message`  | *string* | [optional] monitoring target's message. only exists when the type of monitor is either `"check"` or `"external"` |
-| `reason`  | *string* | [optional] reason that the alert was closed. does not exist if the alert is unresolved. |
-| `openedAt`  | *number* | time stamp when the alert was generated (unix time) |
-| `closedAt`  | *number* | [optional] time stamp when the alert was resolved (unix time). only exists if the alert is already resolved |
+| `id`     | *string*        | the alert's ID                                      |
+| `status` | *string*        | the alert's current status: `"OK"`, `"CRITICAL"`, `"WARNING"`, or `"UNKNOWN"` |
+| `monitorId`  | *string* | the ID of the monitor that generated the alert |
+| `type`  | *string* | the type of the monitor: connectivity (`"connectivity"`), host metric (`"host"`), service metric (`"service"`), external monitor (`"external"`), check monitor (`"check"`), expression monitor (`"expression"`), or anomaly detection for roles (`"anomalyDetection"`) |
+| `hostId`  | *string* | [optional] the associated host ID. only exists when the type of the monitor is either `"connectivity"`, `"host"`, `"check"`, or `"anomalyDetection"` |
+| `value`  | *number* | [optional] the value of the monitoring target. only exists when the type of the monitor is `"host"`, or `"service"` or when there is a reponse time configuration in `"external"` |
+| `message`  | *string* | [optional] the monitoring target's message. only exists when the type of the monitor is either `"check"` or `"external"` |
+| `reason`  | *string* | [optional] the reason the alert closed. does not exist if the alert is unresolved. |
+| `openedAt`  | *number* | the timestamp of when the alert was generated (Unix time) |
+| `closedAt`  | *number* | [optional] the timestamp of when the alert was resolved (Unix time). only exists if the alert is already resolved |
 
 #### Error
 
@@ -76,7 +76,7 @@ Alerts will be in chronological order of when they were generated from newest to
   <tbody>
     <tr>
       <td>400</td>
-      <td>when `limit` value is larger than maximum allowed value(100)</td>
+      <td>when `limit` value is larger than the maximum allowed value (100)</td>
     </tr>
   </tbody>
 </table>
@@ -92,7 +92,7 @@ The designated alert will be closed.
   <code>/api/v0/alerts/<em>&lt;alertId&gt;</em>/close</code> 
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -103,7 +103,7 @@ The designated alert will be closed.
 
 ```javascript
 {
-  "reason": <text>
+  "reason": "<text>"
 }
 ```
 
@@ -120,13 +120,13 @@ A post-update alert will be returned.
   "id": "<alertId>",
   "status": "OK",
   ...
-  "reason": <reason>,
-  "opendAt": <opendAt>,
+  "reason": "<reason>",
+  "openedAt": <openedAt>,
   "closedAt": <closedAt>
 }
 ```
 
-This is the same as the `<alert>` object in [Getting Alerts](#get). `reason` and `closedAt` exist.
+The response object includes the same keys as the `<alert>` object in [Getting Alerts](#get). Here, the `reason` and `closedAt` fields are not optional, they will always exist.
 
 #### Error
 
@@ -140,11 +140,11 @@ This is the same as the `<alert>` object in [Getting Alerts](#get). `reason` and
   <tbody>
     <tr>
       <td>404</td>
-      <td>when the <code><em>&lt;alertId&gt;</em></code>'s corresponding alert can't be found</td>
+      <td>when the alert with the corresponding <code><em>&lt;alertId&gt;</em></code> can't be found</td>
     </tr>
     <tr>
       <td>403</td>
-      <td>when the API doesn't have the required permissions / when accessing from outside the <a href="https://mackerel.io/docs/entry/faq/organization/ip-restriction" target="_blank">permitted IP address range</a></td>
+      <td>when the API key doesn't have the required permissions / when accessing from outside the <a href="https://mackerel.io/docs/entry/faq/organization/ip-restriction" target="_blank">permitted IP address range</a></td>
     </tr>
   </tbody>
 </table>

--- a/content/ja/api-docs/entry/alerts.md
+++ b/content/ja/api-docs/entry/alerts.md
@@ -104,7 +104,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
 
 ```json
 {
-  "reason": <text>
+  "reason": "<text>"
 }
 ```
 `reason` フィールドには任意のテキストを記述できます。このフィールドは必須項目です。
@@ -120,8 +120,8 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
   "id": "<alertId>",
   "status": "OK",
   ...
-  "reason": <reason>,
-  "opendAt": <opendAt>,
+  "reason": "<reason>",
+  "openedAt": <openedAt>,
   "closedAt": <closedAt>
 }
 ```


### PR DESCRIPTION
I've done the same thing for the [Alert Group Settings](https://github.com/mackerelio/documents/pull/4) page too.

## What I have done
- I checked out the Alerts documentation, and did some minor tweaks on the English.
https://mackerel.io/api-docs/entry/alerts
- I made some adjustments to the examples and made sure the English/Japanese show the same thing

## Cautions
- I haven't actually previewed the page with these changes (I've seen the diff for the Markdown so I think it should be okay?)