### PR TITLE
Replace example code marked up by `javascript` with `json`

### DIFF
--- a/content/api-docs/entry/alerts.md
+++ b/content/api-docs/entry/alerts.md
@@ -101,7 +101,7 @@ The designated alert will be closed.
 
 ### Input
 
-```javascript
+```json
 {
   "reason": <text>
 }
@@ -115,7 +115,7 @@ Any text can be appended in the `reason` field. This field is a required item.
 
 A post-update alert will be returned.
 
-```javascript
+```json
 {
   "id": "<alertId>",
   "status": "OK",

--- a/content/api-docs/entry/check-monitoring.md
+++ b/content/api-docs/entry/check-monitoring.md
@@ -27,7 +27,7 @@ If a new monitoring timestamp has already been posted with the same name/host, p
 
 ### Input
 
-```javascript
+```json
 {
   "reports": [ <report>, <report>, … ]
 }
@@ -57,7 +57,7 @@ If a new monitoring timestamp has already been posted with the same name/host, p
 
 #### Success
 
-```javascript
+```json
 {
   "success": true
 }

--- a/content/api-docs/entry/dashboards/legacy.md
+++ b/content/api-docs/entry/dashboards/legacy.md
@@ -53,7 +53,7 @@ Objects that hold the following keys:
 
 The dashboard that was created is returned.
 
-```javascript
+```json
 {
   "id": <dashboardId>,
   "title": "My Dashboard",
@@ -110,7 +110,7 @@ The dashboard that was created is returned.
 
 #### Success
 
-```javascript
+```json
 {
   "id": <dashboardId>,
   "title": "My Dashboard",

--- a/content/api-docs/entry/host-metrics.md
+++ b/content/api-docs/entry/host-metrics.md
@@ -33,7 +33,7 @@ If old values are being transmitted to the API, the values on the Mackerel inter
 
 ### Input
 
-```javascript
+```json
 [ <metricValue>, <metricValue>, … ]
 ```
 
@@ -50,7 +50,7 @@ If old values are being transmitted to the API, the values on the Mackerel inter
 
 #### Success
 
-```javascript
+```json
 {
   "sucess": true
 }
@@ -108,7 +108,7 @@ With the following parameter, the metric name and time span to be collected will
 
 #### Success
 
-```javascript
+```json
 {
   "metrics": [
     {
@@ -176,7 +176,7 @@ With the following parameter, host and metric names will be assigned.
 
 ### Response
 
-```javascript
+```json
 {
   "tsdbLatest": {
     <hostId>: {
@@ -233,7 +233,7 @@ This will transmit custom metric graph definitions to Mackerel.
 
 ### Input
 
-```javascript
+```json
 [ <graphDef>, <graphDef>, … ]
 ```
  
@@ -258,7 +258,7 @@ metric: an object that contains the following keys.
 
 ### Example Input
 
-```javascript
+```json
 [
   {
       "name" : "custom.cpu.foo",
@@ -291,7 +291,7 @@ metric: an object that contains the following keys.
 
 #### Success
 
-```javascript
+```json
 {
   "success": true
 }

--- a/content/api-docs/entry/hosts.md
+++ b/content/api-docs/entry/hosts.md
@@ -323,7 +323,7 @@ If you want to Un-assign roles from a host, please use [Updating host roles](#up
 
 #### Success
 
-```javascript
+```json
 {
   "success": true
 }

--- a/content/api-docs/entry/metadata.md
+++ b/content/api-docs/entry/metadata.md
@@ -107,7 +107,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
 
 ### Response
 
-```javascript
+```json
 {
   "success": true
 }
@@ -168,7 +168,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
 
 #### Success
 
-```javascript
+```json
 {
   "success": true
 }

--- a/content/api-docs/entry/organizations.md
+++ b/content/api-docs/entry/organizations.md
@@ -22,7 +22,7 @@ This will get the information of the organization.
 
 ### Response
 
-```javascript
+```json
 {
   "name": <name>
 }

--- a/content/api-docs/entry/service-metrics.md
+++ b/content/api-docs/entry/service-metrics.md
@@ -31,7 +31,7 @@ If old values are being transmitted to the API, the values on the Mackerel inter
 
 ### Input
 
-```javascript
+```json
 [ <metricValue>, <metricValue>, … ]
 ```
 
@@ -47,7 +47,7 @@ If old values are being transmitted to the API, the values on the Mackerel inter
 
 #### Success
 
-```javascript
+```json
 {
   "success": true
 }
@@ -109,7 +109,7 @@ With the following parameter, the metric name and time span to be collected will
 
 #### Success
 
-```javascript
+```json
 {
   "metrics": [
     {

--- a/content/api-docs/entry/services.md
+++ b/content/api-docs/entry/services.md
@@ -30,7 +30,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 
 ### Response
 
-```javascript
+```json
 {
   "services": [<service>, <service>, ...]
 }
@@ -203,7 +203,7 @@ Arrays will be shown in the order of Role names.
 
 #### Success
 
-```javascript
+```json
 {
   "roles": [<role>, <role>, ...]
 }
@@ -390,7 +390,7 @@ The state of the role just before being deleted will be returned.
 
 #### Success
 
-```javascript
+```json
 {
   "names": [<metricName>, <metricName>, ...]
 }

--- a/content/api-docs/entry/users.md
+++ b/content/api-docs/entry/users.md
@@ -28,7 +28,7 @@ This will get a list of the users belonging to an organization.
 
 ### Response
 
-```javascript
+```json
 {
   "users": [<user>, <user>, ...]
 }

--- a/content/docs/entry/howto/alerts/webhook.md
+++ b/content/docs/entry/howto/alerts/webhook.md
@@ -17,7 +17,7 @@ Notification settings can be added and configured [Webhook form](https://mackere
 
 The JSON that will be sent contains the following. (Items may be added at any time)
 
-```javascript
+```json
 {
   "orgName": "Macker...",
   "event": "alert",

--- a/content/ja/api-docs/entry/hosts.md
+++ b/content/ja/api-docs/entry/hosts.md
@@ -321,7 +321,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
 
 #### 成功時
 
-```javascript
+```json
 {
   "success": true
 }

--- a/content/ja/docs/entry/howto/alerts/webhook.md
+++ b/content/ja/docs/entry/howto/alerts/webhook.md
@@ -18,7 +18,7 @@ Webhookを利用することでアラートの内容のJSONをPOSTで受け取�
 通知されるJSONは以下のような内容を含んでいます。
 (項目は任意のタイミングで追加される場合があります)
 
-```javascript
+```json
 {
   "orgName": "Macker...",
   "event": "alert",


### PR DESCRIPTION
## What I did

- I noticed in the documents that some places used `json` and other places used `javascript`

```sh
# on the master branch

$ git grep "```javascript" | wc -l
      27

$ git grep "```json" | wc -l
     130
```

- I felt these should be consistent, and replaced the `javascript` with `json`
  - especially if it is the API documentation, it makes sense that the response is in `json`

## How will this change the ouput?

Here is an example of `javascript` vs `json`

<img width="283" alt="スクリーンショット 2020-01-04 12 03 11" src="https://user-images.githubusercontent.com/3520520/71759005-3aaf1880-2eea-11ea-87cf-a3cfced5bb61.png">

https://mackerel.io/api-docs/entry/alerts#close

<img width="260" alt="スクリーンショット 2020-01-04 12 03 17" src="https://user-images.githubusercontent.com/3520520/71759012-44388080-2eea-11ea-8dde-4bab5dceb9c2.png">

https://mackerel.io/ja/api-docs/entry/alerts#close