### PR TITLE
[nit] add 'the' for 'Required permissions for the API key'

### DIFF
--- a/content/api-docs/entry/channels.md
+++ b/content/api-docs/entry/channels.md
@@ -18,7 +18,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
   <code>/api/v0/channels</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -79,7 +79,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
   <code>/api/v0/channels</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -266,7 +266,7 @@ Deleting the channel
   <code>/api/v0/channels/<em>&lt;channelId&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>

--- a/content/api-docs/entry/check-monitoring.md
+++ b/content/api-docs/entry/check-monitoring.md
@@ -18,7 +18,7 @@ Implementation described in [Adding a monitoring check item by script](https://m
 If a new monitoring timestamp has already been posted with the same name/host, posting will be ignored.
 
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>

--- a/content/api-docs/entry/dashboards.md
+++ b/content/api-docs/entry/dashboards.md
@@ -24,7 +24,7 @@ This section covers creating dashboards.
   <code>/api/v0/dashboards</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 <ul class="api-key">
   <li class="label-read">Read</li>
   <li class="label-write">Write</li>
@@ -93,7 +93,7 @@ The dashboard that was created is returned.
   <code>/api/v0/dashboards/<em>&lt;dashboardId&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 <ul class="api-key">
   <li class="label-read">Read</li>
 </ul>
@@ -127,7 +127,7 @@ Same as [Creating Dashboards](#create).
   <code>/api/v0/dashboards/<em>&lt;dashboardId&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 <ul class="api-key">
   <li class="label-read">Read</li>
   <li class="label-write">Write</li>
@@ -180,7 +180,7 @@ This will delete the dashboard corresponding to the designated ID.
   <code>/api/v0/dashboards/<em>&lt;dashboardId&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 <ul class="api-key">
   <li class="label-read">Read</li>
   <li class="label-write">Write</li>
@@ -219,7 +219,7 @@ The dashboard before deletion is returned, same as [Creating Dashboards](#create
   <code>/api/v0/dashboards</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 <ul class="api-key">
   <li class="label-read">Read</li>
 </ul>

--- a/content/api-docs/entry/dashboards/legacy.md
+++ b/content/api-docs/entry/dashboards/legacy.md
@@ -26,7 +26,7 @@ This section covers creating dashboards.
 
 It's not possible to specify a URL path that is already being used to create a new dashboard.
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -100,7 +100,7 @@ The dashboard that was created is returned.
   <code>/api/v0/dashboards/<em>&lt;dashboardId&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -150,7 +150,7 @@ The dashboard that was created is returned.
   <code>/api/v0/dashboards/<em>&lt;dashboardId&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -209,7 +209,7 @@ This will delete the dashboard corresponding to the designated ID.
   <code>/api/v0/dashboards/<em>&lt;dashboardId&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>

--- a/content/api-docs/entry/downtimes.md
+++ b/content/api-docs/entry/downtimes.md
@@ -22,7 +22,7 @@ This section covers registering downtime in Mackerel.
   <code>/api/v0/downtimes</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 <ul class="api-key">
   <li class="label-read">Read</li>
   <li class="label-write">Write</li>
@@ -121,7 +121,7 @@ Usable characters are /^[A-Za-z0-9][A-Za-z0-9_-]+$/.
   <code>/api/v0/downtimes</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 <ul class="api-key">
   <li class="label-read">Read</li>
 </ul>
@@ -140,7 +140,7 @@ Usable characters are /^[A-Za-z0-9][A-Za-z0-9_-]+$/.
   <code>/api/v0/downtimes/<em>&lt;downtimeId&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 <ul class="api-key">
   <li class="label-read">Read</li>
   <li class="label-write">Write</li>
@@ -209,7 +209,7 @@ This will delete the downtime corresponding to the designated ID.
   <code>/api/v0/downtimes/<em>&lt;downtimeId&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 <ul class="api-key">
   <li class="label-read">Read</li>
   <li class="label-write">Write</li>

--- a/content/api-docs/entry/graph-annotations.md
+++ b/content/api-docs/entry/graph-annotations.md
@@ -19,7 +19,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
   <code>/api/v0/graph-annotations</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -94,7 +94,7 @@ Specify the service and interval and obtain the graph annotations list. Annotati
   <code>/api/v0/graph-annotations</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key border-none">
   <li class="label-read">Read</li>
@@ -162,7 +162,7 @@ Specify the service and interval and obtain the graph annotations list. Annotati
   <code>/api/v0/graph-annotations/<em>&lt;annotationId&gt</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -221,7 +221,7 @@ The same as [Creating graph annotations](#create), the input is returned with an
   <code>/api/v0/graph-annotations/<em>&lt;annotationId&gt</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>

--- a/content/api-docs/entry/host-metrics.md
+++ b/content/api-docs/entry/host-metrics.md
@@ -24,7 +24,7 @@ This will transmit metrics collected by the agent to Mackerel. Recorded values c
 
 If old values are being transmitted to the API, the values on the Mackerel interface will be overwritten. If posting with a timestamp older than 24 hours, those metrics will not be recorded (a status code 200 response will be returned). Additionally, an alert will not occur for an old value, even if a threshold is surpassed, since alerts occur based on the latest values from the Mackerel interface.
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -88,7 +88,7 @@ This will get metric values that have been posted by the agent.
   <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/metrics</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -159,7 +159,7 @@ This will get the latest metrics posted by the agent from each host.
   <code>/api/v0/tsdb/latest</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -224,7 +224,7 @@ This will transmit custom metric graph definitions to Mackerel.
   <code>/api/v0/graph-defs/create</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>

--- a/content/api-docs/entry/hosts.md
+++ b/content/api-docs/entry/hosts.md
@@ -26,7 +26,7 @@ Registering an agent-running host to Mackerel.
   <code>/api/v0/hosts</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -143,7 +143,7 @@ One element of `checks` is an object that holds the following keys.
   <code>/api/v0/hosts/<em>&lt;hostId&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -184,7 +184,7 @@ One element of `checks` is an object that holds the following keys.
   <code>/api/v0/hosts/<em>&lt;hostId&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -242,7 +242,7 @@ If you want to Un-assign roles from a host, please use [Updating host roles](#up
   <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/status</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -303,7 +303,7 @@ If you want to Un-assign roles from a host, please use [Updating host roles](#up
   <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/role-fullnames</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-write">Write</li>
@@ -369,7 +369,7 @@ This will retire a registered host.
   <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/retire</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -431,7 +431,7 @@ This will POST empty JSON.
 
 `/api/v0/hosts.json` returns the same contents with the same query parameters.
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -468,7 +468,7 @@ The following parameter will extract hosts. If nothing has yet been assigned, al
   <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/metric-names</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>

--- a/content/api-docs/entry/invitations.md
+++ b/content/api-docs/entry/invitations.md
@@ -19,7 +19,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
   <code>/api/v0/invitations</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -53,7 +53,7 @@ Specify an email address and permission and invite a user to the organization.
   <code>/api/v0/invitations</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -119,7 +119,7 @@ Specify the email address and cancel an invitation to the organization.
   <code>/api/v0/invitations/revoke</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>

--- a/content/api-docs/entry/metadata.md
+++ b/content/api-docs/entry/metadata.md
@@ -50,7 +50,7 @@ Obtain registered metadata.
   <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key border-none">
   <li class="label-read">Read</li>
@@ -94,7 +94,7 @@ Create and update arbitrary JSON as metadata of the host.
   <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -157,7 +157,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
   <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -210,7 +210,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
   <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/metadata</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -275,7 +275,7 @@ Obtain registered metadata.
   <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key border-none">
   <li class="label-read">Read</li>
@@ -315,7 +315,7 @@ Create and update arbitrary JSON as metadata of the service.
   <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -374,7 +374,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
   <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -423,7 +423,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
   <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/metadata</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -484,7 +484,7 @@ Obtain registered metadata.
   <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/roles/<em>&lt;roleName&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key border-none">
   <li class="label-read">Read</li>
@@ -524,7 +524,7 @@ Create and update arbitrary JSON as metadata of the role.
   <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/roles/<em>&lt;roleName&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -583,7 +583,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
   <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/roles/<em>&lt;roleName&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -632,7 +632,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
   <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/roles/<em>&lt;roleName&gt;</em>/metadata</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>

--- a/content/api-docs/entry/monitors.md
+++ b/content/api-docs/entry/monitors.md
@@ -24,7 +24,7 @@ The input procedure varies depending on the monitoring target.
   <code>/api/v0/monitors</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key border-none">
   <li class="label-read">Read</li>
@@ -609,7 +609,7 @@ In order to monitor response time, it's necessary to assign `responseTimeWarning
   <code>/api/v0/monitors</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -792,7 +792,7 @@ In order to monitor response time, it's necessary to assign `responseTimeWarning
   <code>/api/v0/monitors/<em>&lt;monitorId&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -837,7 +837,7 @@ In order to monitor response time, it's necessary to assign `responseTimeWarning
 As for requests and responses, just as when [creating monitors](#create), every field must be specified. If there are any insufficient items that are required, an error will be generated.
 When `scopes` and `excludeScopes` are updated, the JSON which was designated will be completely overwritten. For example, by omitting an item in `scopes` when it has already been saved, `scopes` will be deleted. 
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -894,7 +894,7 @@ same errors as when [creating](#create).
   <code>/api/v0/monitors/<em>&lt;monitorId&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>

--- a/content/api-docs/entry/notification-groups.md
+++ b/content/api-docs/entry/notification-groups.md
@@ -20,7 +20,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
   <code>/api/v0/notification-groups</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key border-none">
   <li class="label-read">Read</li>
@@ -113,7 +113,7 @@ The input is returned along with an ID.
   <code>/api/v0/notification-groups</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key border-none">
   <li class="label-read">Read</li>
@@ -136,7 +136,7 @@ The input is returned along with an ID.
   <code>/api/v0/notification-groups/<em>&lt;notificationGroupId&gt</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key border-none">
   <li class="label-read">Read</li>
@@ -192,7 +192,7 @@ The organization’s default notification group can not be deleted
   <code>/api/v0/notification-groups/<em>&lt;notificationGroupId&gt</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key border-none">
   <li class="label-read">Read</li>

--- a/content/api-docs/entry/organizations.md
+++ b/content/api-docs/entry/organizations.md
@@ -14,7 +14,7 @@ This will get the information of the organization.
   <code>/api/v0/org</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>

--- a/content/api-docs/entry/service-metrics.md
+++ b/content/api-docs/entry/service-metrics.md
@@ -22,7 +22,7 @@ This will transmit metrics tied to services to Mackerel.
 
 If old values are being transmitted to the API, the values on the Mackerel interface will be overwritten. If posting with a timestamp older than 24 hours, those metrics will not be recorded (a status code 200 response will be returned). Additionally, an alert will not occur for an old value, even if a threshold is surpassed, since alerts occur based on the latest values from the Mackerel interface.
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -89,7 +89,7 @@ This will get metric values connected to services.
   <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/metrics</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>

--- a/content/api-docs/entry/services.md
+++ b/content/api-docs/entry/services.md
@@ -22,7 +22,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
   <code>/api/v0/services</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -55,7 +55,7 @@ Arrays will be shown in the order of Role names.
   <code>/api/v0/services</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
  <ul class="api-key">
   <li class="label-read">Read</li>
@@ -135,7 +135,7 @@ The created service will be returned. The format will be the same as <i>`<servic
 
 Roles, service metrics, monitoring configurations, and graph annotations associated with the service will also be deleted.
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -193,7 +193,7 @@ Arrays will be shown in the order of Role names.
   <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/roles</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -245,7 +245,7 @@ Arrays will be shown in the order of Role names.
   <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/roles</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
  
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -326,7 +326,7 @@ The created role will be returned. The format will be the same as <i>`<role>`</i
   <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/roles/<em>&lt;roleName&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -380,7 +380,7 @@ The state of the role just before being deleted will be returned.
   <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/metric-names</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>

--- a/content/api-docs/entry/users.md
+++ b/content/api-docs/entry/users.md
@@ -20,7 +20,7 @@ This will get a list of the users belonging to an organization.
   <code>/api/v0/users</code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>
@@ -58,7 +58,7 @@ This will delete users belonging to an organization.
   <code>/api/v0/users/<em>&lt;userId&gt;</em></code>
 </p>
 
-### Required permissions for API key
+### Required permissions for the API key
 
 <ul class="api-key">
   <li class="label-read">Read</li>


### PR DESCRIPTION
## What I did
I thought `Required permissions for API key` needs a `the` in it to be grammatically correct so I did a "find and replace". 