### PR TITLE
Adjust the API Document headers to make them consistent

### DIFF
--- a/content/api-docs/entry/alert-group-settings.md
+++ b/content/api-docs/entry/alert-group-settings.md
@@ -7,14 +7,14 @@ CustomPath: alert-group-settings
 ---
 
 <ul class="internal-nav">
-  <li><a href="#list">Listing alert group settings</a></li>
-  <li><a href="#create">Creating alert group settings</a></li>
-  <li><a href="#get">Getting alert group settings</a></li>
-  <li><a href="#update">Updating alert group settings</a></li>
-  <li><a href="#delete">Deleting alert group settings</a></li>
+  <li><a href="#list">Listing Alert Group Settings</a></li>
+  <li><a href="#create">Creating Alert Group Settings</a></li>
+  <li><a href="#get">Getting Alert Group Settings</a></li>
+  <li><a href="#update">Updating Alert Group Settings</a></li>
+  <li><a href="#delete">Deleting Alert Group Settings</a></li>
 </ul>
 
-<h2 id="list">Listing alert group settings</h2>
+<h2 id="list">Listing Alert Group Settings</h2>
 
 <p class="type-get">
   <code>GET</code>
@@ -64,7 +64,7 @@ A role's fullname is an array in the format of `<service name>:<role name>`.
 
 available strings for the role fullname must match the following regular expression: `/^[A-Za-z0-9][A-Za-z0-9_-]+$/`
 
-<h2 id="create">Creating alert group settings</h2>
+<h2 id="create">Creating Alert Group Settings</h2>
 
 <p class="type-post">
   <code>POST</code>
@@ -93,7 +93,7 @@ available strings for the role fullname must match the following regular express
 
 #### Success
 
-The created alert group setting is returned. The response format is the same as that which can be obtained with [Listing alert group settings](#list).
+The created alert group setting is returned. The response format is the same as that which can be obtained with [Listing Alert Group Settings](#list).
 
 #### Error
 
@@ -116,7 +116,7 @@ The created alert group setting is returned. The response format is the same as 
   </tbody>
 </table>
 
-<h2 id="get">Getting alert group settings</h2>
+<h2 id="get">Getting Alert Group Settings</h2>
 
 <p class="type-get">
   <code>GET</code>
@@ -133,7 +133,7 @@ The created alert group setting is returned. The response format is the same as 
 
 #### Success
 
-The alert group setting is returned. The response format is the same as that which can be obtained with [Listing alert group settings](#list).
+The alert group setting is returned. The response format is the same as that which can be obtained with [Listing Alert Group Settings](#list).
 
 #### Error
 
@@ -160,7 +160,7 @@ The alert group setting is returned. The response format is the same as that whi
   </tbody>
 </table>
 
-<h2 id="update">Updating alert group settings</h2>
+<h2 id="update">Updating Alert Group Settings</h2>
 
 <p class="type-put">
   <code>PUT</code>
@@ -176,13 +176,13 @@ The alert group setting is returned. The response format is the same as that whi
 
 ### Input
 
-The same format as [Creating alert group settings](#create).
+The same format as [Creating Alert Group Settings](#create).
 
 ### Response
 
 #### Success
 
-The updated alert group setting is returned. The response format is the same as that which can be obtained with [Listing alert group settings](#list).
+The updated alert group setting is returned. The response format is the same as that which can be obtained with [Listing Alert Group Settings](#list).
 
 #### Error
 
@@ -209,7 +209,7 @@ The updated alert group setting is returned. The response format is the same as 
   </tbody>
 </table>
 
-<h2 id="delete">Deleting alert group settings</h2>
+<h2 id="delete">Deleting Alert Group Settings</h2>
 
 <p class="type-delete">
   <code>DELETE</code>
@@ -227,7 +227,7 @@ The updated alert group setting is returned. The response format is the same as 
 
 #### Success
 
-The deleted alert group setting is returned. The response format is the same as that which can be obtained with [Listing alert group settings](#list).
+The deleted alert group setting is returned. The response format is the same as that which can be obtained with [Listing Alert Group Settings](#list).
 
 #### Error
 

--- a/content/api-docs/entry/channels.md
+++ b/content/api-docs/entry/channels.md
@@ -6,9 +6,9 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 ---
 
 <ul class="internal-nav">
-  <li><a href="#get">Get notification channel list</a></li>
-  <li><a href="#create">Register notification channels</a></li>
-  <li><a href="#delete">Delete notification channels</a></li>
+  <li><a href="#get">Getting Notification Channels</a></li>
+  <li><a href="#create">Registering Notification Channels</a></li>
+  <li><a href="#delete">Deleting Notification Channels</a></li>
 </ul>
 
 <h2 id="get">Notification channel list</h2>
@@ -70,7 +70,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 
 ----------------------------------------------
 
-<h2 id="create">Register notification channels</h2>
+<h2 id="create">Registering Notification Channels</h2>
 
 ※Currently supported for email, Slack, and Webhook.
 
@@ -257,7 +257,7 @@ The object contains the following keys
 
 ----------------------------------------------
 
-<h2 id="delete">Delete notification channels</h2>
+<h2 id="delete">Deleting Notification Channels</h2>
 
 Deleting the channel
 

--- a/content/api-docs/entry/check-monitoring.md
+++ b/content/api-docs/entry/check-monitoring.md
@@ -5,7 +5,7 @@ URL: https://mackerel.io/api-docs/entry/check-monitoring
 EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel.io/atom/entry/10328537792368374608
 ---
 
-<h2 id="post">Posting monitoring check reports</h2>
+<h2 id="post">Posting Monitoring Check Reports</h2>
 
 This will transmit a monitoring check’s report to Mackerel. Monitoring reports are restricted to hosts.
 

--- a/content/api-docs/entry/check-monitoring.md
+++ b/content/api-docs/entry/check-monitoring.md
@@ -14,7 +14,7 @@ This will transmit a monitoring check’s report to Mackerel. Monitoring reports
   <code>/api/v0/monitoring/checks/report</code>
 </p>
 
-Implementation described in [Adding a monitoring check item by script](https://mackerel.io/docs/entry/custom-checks) is being used. The agent will periodically transmit the list of configured monitoring checks to the [Updating host information](/api-docs/entry/hosts#update-information) API and, any monitoring checks that aren’t included in that list and do not have open alerts will be deleted from Mackerel at that time.
+Implementation described in [Adding a monitoring check item by script](https://mackerel.io/docs/entry/custom-checks) is being used. The agent will periodically transmit the list of configured monitoring checks to the [Updating Host Information](/api-docs/entry/hosts#update-information) API and, any monitoring checks that aren’t included in that list and do not have open alerts will be deleted from Mackerel at that time.
 If a new monitoring timestamp has already been posted with the same name/host, posting will be ignored.
 
 

--- a/content/api-docs/entry/dashboards.md
+++ b/content/api-docs/entry/dashboards.md
@@ -10,7 +10,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
   <li><a href="#get">Getting Dashboards</a></li>
   <li><a href="#update">Updating Dashboards</a></li>
   <li><a href="#delete">Deleting Dashboards</a></li>
-  <li><a href="#list">List of Dashboards</a></li>
+  <li><a href="#list">Listing Dashboards</a></li>
 </ul>
 
 This page explains Custom Dashboards following the feature's renovation as of November 2018. For details regarding the API operating this feature before its renovation, refer [here](https://mackerel.io/api-docs/entry/dashboards/legacy).
@@ -213,7 +213,7 @@ The dashboard before deletion is returned, same as [Creating Dashboards](#create
 
 ----------------------------------------------
 
-<h2 id="list">List of Dashboards</h2>
+<h2 id="list">Listing Dashboards</h2>
 <p class="type-get">
   <code>GET</code>
   <code>/api/v0/dashboards</code>

--- a/content/api-docs/entry/downtimes.md
+++ b/content/api-docs/entry/downtimes.md
@@ -6,14 +6,14 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 ---
 
 <ul class="internal-nav">
-  <li><a href="#create">Register Downtime</a></li>
-  <li><a href="#list">Downtime List</a></li>
-  <li><a href="#update">Update Downtime</a></li>
-  <li><a href="#delete">Delete Downtime</a></li>
+  <li><a href="#create">Registering Downtimes</a></li>
+  <li><a href="#list">Listing Downtimes</a></li>
+  <li><a href="#update">Updating Downtimes</a></li>
+  <li><a href="#delete">Deleting Downtimes</a></li>
 </ul>
 
 
-<h2 id="create">Register Downtime</h2>
+<h2 id="create">Registering Downtimes</h2>
 
 This section covers registering downtime in Mackerel.
 
@@ -115,7 +115,7 @@ Usable characters are /^[A-Za-z0-9][A-Za-z0-9_-]+$/.
 
 ----------------------------------------------
 
-<h2 id="list">Downtime List</h2>
+<h2 id="list">Listing Downtimes</h2>
 <p class="type-get">
   <code>GET</code>
   <code>/api/v0/downtimes</code>
@@ -134,7 +134,7 @@ Usable characters are /^[A-Za-z0-9][A-Za-z0-9_-]+$/.
 
 ----------------------------------------------
 
-<h2 id="update">Update Downtime</h2>
+<h2 id="update">Updating Downtimes</h2>
 <p class="type-put">
   <code>PUT</code>
   <code>/api/v0/downtimes/<em>&lt;downtimeId&gt;</em></code>
@@ -147,11 +147,11 @@ Usable characters are /^[A-Za-z0-9][A-Za-z0-9_-]+$/.
 </ul>
 
 ### Input
-Same as [Register Downtime](#create).
+Same as [Registering Downtimes](#create).
 
 ### Response
 #### Success
-The updated downtime is returned. Same format as [Register Downtime](#create).
+The updated downtime is returned. Same format as [Registering Downtimes](#create).
 
 #### Error
 
@@ -200,7 +200,7 @@ The updated downtime is returned. Same format as [Register Downtime](#create).
 
 ----------------------------------------------
 
-<h2 id="delete">Delete Downtime</h2>
+<h2 id="delete">Deleting Downtimes</h2>
 
 This will delete the downtime corresponding to the designated ID.
 
@@ -217,7 +217,7 @@ This will delete the downtime corresponding to the designated ID.
 
 ### Response
 #### Success
-The downtime before deletion is returned, same as [Register Downtime](#create).
+The downtime before deletion is returned, same as [Registering Downtimes](#create).
 
 #### Error
 

--- a/content/api-docs/entry/graph-annotations.md
+++ b/content/api-docs/entry/graph-annotations.md
@@ -6,14 +6,14 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 ---
 
 <ul class="internal-nav">
-  <li><a href="#create">Creating graph annotations</a></li>
-  <li><a href="#get">Obtaining graph annotations</a></li>
-  <li><a href="#update">Updating graph annotations</a></li>
-  <li><a href="#delete">Deleting graph annotations</a></li>
+  <li><a href="#create">Creating Graph Annotations</a></li>
+  <li><a href="#get">Obtaining Graph Annotations</a></li>
+  <li><a href="#update">Updating Graph Annotations</a></li>
+  <li><a href="#delete">Deleting Graph Annotations</a></li>
 </ul>
 
 
-<h2 id="create">Creating graph annotations</h2>
+<h2 id="create">Creating Graph Annotations</h2>
 <p class="type-post">
   <code>POST</code>
   <code>/api/v0/graph-annotations</code>
@@ -85,7 +85,7 @@ The input is returned along with an ID.
   </tbody>
 </table>
 
-<h2 id="get">Obtaining graph annotations</h2>
+<h2 id="get">Obtaining Graph Annotations</h2>
 
 Specify the service and interval and obtain the graph annotations list. Annotations with intervals intersecting with the specified interval will all be returned.
 
@@ -155,7 +155,7 @@ Specify the service and interval and obtain the graph annotations list. Annotati
   </tbody>
 </table>
 
-<h2 id="update">Updating graph annotations</h2>
+<h2 id="update">Updating Graph Annotations</h2>
 
 <p class="type-put">
   <code>PUT</code>
@@ -171,11 +171,11 @@ Specify the service and interval and obtain the graph annotations list. Annotati
 
 ### Input
 
-The same as [Creating graph annotations](#create).
+The same as [Creating Graph Annotations](#create).
 
 ### Response
 
-The same as [Creating graph annotations](#create), the input is returned with an ID.
+The same as [Creating Graph Annotations](#create), the input is returned with an ID.
 
 #### Error
 
@@ -214,7 +214,7 @@ The same as [Creating graph annotations](#create), the input is returned with an
   </tbody>
 </table>
 
-<h2 id="delete">Deleting graph annotations</h2>
+<h2 id="delete">Deleting Graph Annotations</h2>
 
 <p class="type-delete">
   <code>DELETE</code>

--- a/content/api-docs/entry/host-metrics.md
+++ b/content/api-docs/entry/host-metrics.md
@@ -6,14 +6,14 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 ---
 
 <ul class="internal-nav">
-  <li><a href="#post">Posting metrics</a></li>
-  <li><a href="#get">Getting host metrics</a></li>
-  <li><a href="#get-latest">Getting latest metrics</a></li>
-  <li><a href="#post-graphdef">Posting graph definitions</a></li>
+  <li><a href="#post">Posting Metrics</a></li>
+  <li><a href="#get">Getting Host Metrics</a></li>
+  <li><a href="#get-latest">Getting Latest Metrics</a></li>
+  <li><a href="#post-graphdef">Posting Graph Definitions</a></li>
 </ul>
 
 
-<h2 id="post">Posting metrics</h2>
+<h2 id="post">Posting Metrics</h2>
 
 This will transmit metrics collected by the agent to Mackerel. Recorded values can be checked using web graphs, etc.
 
@@ -79,7 +79,7 @@ If old values are being transmitted to the API, the values on the Mackerel inter
 
 ----------------------------------------------
 
-<h2 id="get">Getting host metrics</h2>
+<h2 id="get">Getting Host Metrics</h2>
 
 This will get metric values that have been posted by the agent.
 
@@ -150,7 +150,7 @@ With the following parameter, the metric name and time span to be collected will
 
 ----------------------------------------------
 
-<h2 id="get-latest">Getting latest metrics</h2>
+<h2 id="get-latest">Getting Latest Metrics</h2>
 
 This will get the latest metrics posted by the agent from each host. 
 
@@ -215,7 +215,7 @@ With the following parameter, host and metric names will be assigned.
 
 ----------------------------------------------
 
-<h2 id="post-graphdef">Posting graph definitions</h2>
+<h2 id="post-graphdef">Posting Graph Definitions</h2>
 
 This will transmit custom metric graph definitions to Mackerel.
 

--- a/content/api-docs/entry/hosts.md
+++ b/content/api-docs/entry/hosts.md
@@ -6,18 +6,18 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 ---
 
 <ul class="internal-nav">
-  <li><a href="#create">Registering host information</a></li>
-  <li><a href="#get">Getting host information</a></li>
-  <li><a href="#update-information">Updating host information</a></li>
-  <li><a href="#update-status">Updating host status</a></li>
-  <li><a href="#update-roles">Updating host roles</a></li>
-  <li><a href="#retire">Retiring hosts</a></li>
-  <li><a href="#list">List of hosts</a></li>
-  <li><a href="#metric-names">List of metric names</a></li>
+  <li><a href="#create">Registering Host Information</a></li>
+  <li><a href="#get">Getting Host Information</a></li>
+  <li><a href="#update-information">Updating Host Information</a></li>
+  <li><a href="#update-status">Updating Host Status</a></li>
+  <li><a href="#update-roles">Updating Host Roles</a></li>
+  <li><a href="#retire">Retiring Hosts</a></li>
+  <li><a href="#list">Listing Hosts</a></li>
+  <li><a href="#metric-names">Listing Metric Names</a></li>
 </ul>
 
 
-<h2 id="create">Registering host information</h2>
+<h2 id="create">Registering Host Information</h2>
 
 Registering an agent-running host to Mackerel.
 
@@ -136,7 +136,7 @@ One element of `checks` is an object that holds the following keys.
 
 ----------------------------------------------
 
-<h2 id="get">Getting host information</h2>
+<h2 id="get">Getting Host Information</h2>
 
 <p class="type-get">
   <code>GET</code>
@@ -177,7 +177,7 @@ One element of `checks` is an object that holds the following keys.
 
 ----------------------------------------------
 
-<h2 id="update-information">Updating host information</h2>
+<h2 id="update-information">Updating Host Information</h2>
 
 <p class="type-put">
   <code>PUT</code>
@@ -193,10 +193,10 @@ One element of `checks` is an object that holds the following keys.
 
 ### Input
 
-Same as [Registering host information](#create).
+Same as [Registering Host Information](#create).
 
 A host remains to belong to the roles which you didn't specify by `roleFullnames`.
-If you want to Un-assign roles from a host, please use [Updating host roles](#update-roles) API.
+If you want to Un-assign roles from a host, please use [Updating Host Roles](#update-roles) API.
 
 ### Response
 
@@ -235,7 +235,7 @@ If you want to Un-assign roles from a host, please use [Updating host roles](#up
 
 ----------------------------------------------
 
-<h2 id="update-status">Updating host status</h2>
+<h2 id="update-status">Updating Host Status</h2>
 
 <p class="type-post">
   <code>POST</code>
@@ -296,7 +296,7 @@ If you want to Un-assign roles from a host, please use [Updating host roles](#up
 
 ----------------------------------------------
 
-<h2 id="update-roles">Updating host roles</h2>
+<h2 id="update-roles">Updating Host Roles</h2>
 
 <p class="type-put">
   <code>PUT</code>
@@ -317,7 +317,7 @@ If you want to Un-assign roles from a host, please use [Updating host roles](#up
 }
 ```
 
-`roleFullnames` is the same as  `roleFullnames` object in [Registering host information](#create).
+`roleFullnames` is the same as  `roleFullnames` object in [Registering Host Information](#create).
 
 ### Response
 
@@ -360,7 +360,7 @@ If you want to Un-assign roles from a host, please use [Updating host roles](#up
 
 ----------------------------------------------
 
-<h2 id="retire">Retiring hosts</h2>
+<h2 id="retire">Retiring Hosts</h2>
 
 This will retire a registered host.
 
@@ -448,7 +448,7 @@ The following parameter will extract hosts. If nothing has yet been assigned, al
 | `role` | *string* | [optional] role names in the service, multiple assignments possible (result will be a unit of the hosts that belong to each role) if `service` has not been assigned it will be ignored.|
 | `name` | *string* | [optional] host name |
 | `status` | *string* | [optional] extract host status, multiple assignments possible, defaults are `working` and `standby`. |
-| `customIdentifier`    | *string*        | [optional] user-specific identifier for the host (registered at [Registering host information](#create) or [Updating host information](#update-information) API) |
+| `customIdentifier`    | *string*        | [optional] user-specific identifier for the host (registered at [Registering Host Information](#create) or [Updating Host Information](#update-information) API) |
 
 ### Response
 
@@ -457,11 +457,11 @@ The following parameter will extract hosts. If nothing has yet been assigned, al
   "hosts": [ <host>, <host>, …]
 }
 ```
-<i>`<host>`</i> is the same type as the object that changes in [Getting host information](#get)
+<i>`<host>`</i> is the same type as the object that changes in [Getting Host Information](#get)
 
 ----------------------------------------------
 
-<h2 id="metric-names">List of metric names</h2>
+<h2 id="metric-names">Listing Metric Names</h2>
 
 <p class="type-get">
   <code>GET</code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -392,7 +392,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/monitors#list">
-          <p>List of monitor configurations</p>
+          <p>Listing Monitor Configurations</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/monitors</code>
@@ -401,7 +401,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/monitors#get">
-          <p>Get monitor configurations</p>
+          <p>Getting Monitor Configurations</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/monitors/<em>&lt;monitorId&gt;</em></code>
@@ -410,7 +410,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/monitors#update">
-          <p>Update monitor configurations</p>
+          <p>Updating Monitor Configurations</p>
           <p class="type-put">
             <code>PUT</code>
             <code>/api/v0/monitors/<em>&lt;monitorId&gt;</em></code>
@@ -419,7 +419,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/monitors#delete">
-          <p>Delete monitor configurations</p>
+          <p>Deleting Monitor Configurations</p>
           <p class="type-delete">
             <code>DELETE</code>
             <code>/api/v0/monitors/<em>&lt;monitorId&gt;</em></code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -720,7 +720,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
     <div class="apis">
       <div class="api">
         <a href="entry/users#list">
-          <p>List of users</p>
+          <p>Listing Users</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/users</code>
@@ -729,7 +729,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/users#delete">
-          <p>Delete users</p>
+          <p>Deleting Users</p>
           <p class="type-delete">
             <code>DELETE</code>
             <code>/api/v0/users/<em>&lt;userId&gt;</em></code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -778,7 +778,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
     <div class="apis">
       <div class="api">
         <a href="entry/organizations#get">
-          <p>Get organization information</p>
+          <p>Getting Organization Information</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/org</code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -434,7 +434,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
     <div class="apis">
       <div class="api">
         <a href="entry/downtimes#create">
-          <p>Register Downtimes</p>
+          <p>Registering Downtimes</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/downtimes</code>
@@ -443,7 +443,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/downtimes#list">
-          <p>List of downtimes</p>
+          <p>Listing Downtimes</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/downtimes</code>
@@ -452,7 +452,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/downtimes#update">
-          <p>Update downtimes</p>
+          <p>Updating Downtimes</p>
           <p class="type-put">
             <code>PUT</code>
             <code>/api/v0/downtimes/<em>&lt;downtimeId&gt;</em></code>
@@ -461,7 +461,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/downtimes#delete">
-          <p>Delete downtimes</p>
+          <p>Deleting Downtimes</p>
           <p class="type-delete">
             <code>DELETE</code>
             <code>/api/v0/downtimes/<em>&lt;downtimeId&gt;</em></code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -250,11 +250,11 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
   </div>
   
   <div class="index-row">
-    <h3><a href="entry/check-monitoring">Check monitoring</a></h3>
+    <h3><a href="entry/check-monitoring">Check Monitoring</a></h3>
     <div class="apis">  
       <div class="api">
         <a href="entry/check-monitoring#post">
-          <p>Posting monitoring check reports</p>
+          <p>Posting Monitoring Check Reports</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/monitoring/checks/report</code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -269,7 +269,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
     <div class="apis">
       <div class="api">
         <a href="entry/metadata#get">
-          <p>Get host metadata</p>
+          <p>Getting Host Metadata</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
@@ -278,7 +278,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/metadata#hostput">
-          <p>Create / Update host metadata</p>
+          <p>Registering/Updating Host Metadata</p>
           <p class="type-put">
             <code>PUT</code>
             <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
@@ -287,7 +287,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/metadata#hostdelete">
-          <p>Delete host metadata</p>
+          <p>Deleting Host Metadata</p>
           <p class="type-delete">
             <code>DELETE</code>
             <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
@@ -296,7 +296,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/metadata#hostlist">
-          <p>List host metadata</p>
+          <p>Listing Host Metadata</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/metadata</code>
@@ -305,7 +305,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/metadata#serviceget">
-          <p>Get service metadata</p>
+          <p>Getting Service Metadata</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
@@ -314,7 +314,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/metadata#serviceput">
-          <p>Register / Update service metadata</p>
+          <p>Registering/Updating Service Metadata</p>
           <p class="type-put">
             <code>PUT</code>
             <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
@@ -323,7 +323,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/metadata#servicedelete">
-          <p>Delete service metadata</p>
+          <p>Deleting Service Metadata</p>
           <p class="type-delete">
             <code>DELETE</code>
             <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
@@ -332,7 +332,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/metadata#servicelist">
-          <p>List of service metadata</p>
+          <p>Listing Service Metadata</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/metadata</code>
@@ -341,7 +341,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/metadata#roleget">
-          <p>Get role metadata</p>
+          <p>Getting Role Metadata</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/roles/<em>&lt;roleName&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
@@ -350,7 +350,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/metadata#roleput">
-          <p>Register / Update role metadata</p>
+          <p>Registering/Updating Role Metadata</p>
           <p class="type-put">
             <code>PUT</code>
             <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/roles/<em>&lt;roleName&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
@@ -359,7 +359,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/metadata#roledelete">
-          <p>Delete role metadata</p>
+          <p>Deleting Role Metadata</p>
           <p class="type-delete">
             <code>DELETE</code>
             <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/roles/<em>&lt;roleName&gt;</em>/metadata/<em>&lt;namespace&gt</em></code>
@@ -368,7 +368,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/metadata#rolelist">
-          <p>List of role metadata</p>
+          <p>Listing Role Metadata</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/roles/<em>&lt;roleName&gt;</em>/metadata</code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -110,7 +110,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
     <div class="apis">
       <div class="api">
         <a href="entry/hosts#create">
-          <p>Registering host information</p>
+          <p>Registering Host Information</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/hosts</code>
@@ -119,7 +119,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/hosts#get">
-          <p>Getting host information</p>
+          <p>Getting Host Information</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/hosts/<em>&lt;hostId&gt;</em></code>
@@ -128,7 +128,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/hosts#update-information">
-          <p>Updating host information</p>
+          <p>Updating Host Information</p>
           <p class="type-put">
             <code>PUT</code>
             <code>/api/v0/hosts/<em>&lt;hostId&gt;</em></code>
@@ -137,7 +137,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/hosts#update-status">
-          <p>Updating host status</p>
+          <p>Updating Host Status</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/status</code>
@@ -146,7 +146,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/hosts#update-roles">
-          <p>Updating host roles</p>
+          <p>Updating Host Roles</p>
           <p class="type-put">
             <code>PUT</code>
             <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/role-fullnames</code>
@@ -155,7 +155,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/hosts#retire">
-          <p>Retiring hosts</p>
+          <p>Retiring Hosts</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/retire</code>
@@ -164,7 +164,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/hosts#list">
-          <p>List of hosts</p>
+          <p>Listing Hosts</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/hosts</code>
@@ -173,7 +173,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/hosts#metric-names">
-          <p>List of metric names</p>
+          <p>Listing Metric Names</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/metric-names</code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -188,7 +188,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
     <div class="apis">
       <div class="api">
         <a href="entry/host-metrics#post">
-          <p>Posting metrics</p>
+          <p>Posting Metrics</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/tsdb</code>
@@ -197,7 +197,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/host-metrics#get">
-          <p>Getting host metrics</p>
+          <p>Getting Host Metrics</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/hosts/<em>&lt;hostId&gt;</em>/metrics</code>
@@ -206,7 +206,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/host-metrics#get-latest">
-        <p>Getting latest metrics</p>
+        <p>Getting Latest Metrics</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/tsdb/latest</code>
@@ -215,7 +215,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/host-metrics#post-graphdef">
-          <p>Posting graph definitions</p>
+          <p>Posting Graph Definitions</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/graph-defs/create</code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -673,11 +673,11 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
   </div>
 
   <div class="index-row">
-    <h3><a href="entry/graph-annotations">Graph annotations</a></h3>
+    <h3><a href="entry/graph-annotations">Graph Annotations</a></h3>
     <div class="apis">
       <div class="api">
         <a href="entry/graph-annotations#create">
-          <p>Creating graph annotations</p>
+          <p>Creating Graph Annotations</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/graph-annotations</code>
@@ -686,7 +686,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/graph-annotations#get">
-          <p>Obtaining graph annotations</p>
+          <p>Obtaining Graph Annotations</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/graph-annotations</em></code>
@@ -695,7 +695,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/graph-annotations#update">
-          <p>Updating graph annotations</p>
+          <p>Updating Graph Annotations</p>
           <p class="type-put">
             <code>PUT</code>
             <code>/api/v0/graph-annotations/<em>&lt;annotationId&gt;</em></code>
@@ -704,7 +704,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/graph-annotations#delete">
-          <p>Deleting graph annotations</p>
+          <p>Deleting Graph Annotations</p>
           <p class="type-delete">
             <code>DELETE</code>
             <code>/api/v0/graph-annotations/<em>&lt;annotationId&gt;</em></code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -226,11 +226,11 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
   </div>
   
   <div class="index-row">
-    <h3><a href="entry/service-metrics">Service metric</a></h3>
+    <h3><a href="entry/service-metrics">Service Metrics</a></h3>
     <div class="apis">
       <div class="api">
         <a href="entry/service-metrics#post">
-          <p>Posting service metrics</p>
+          <p>Posting Service Metrics</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/tsdb</code>
@@ -239,7 +239,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/service-metrics#get">
-        <p>Getting service metrics</p>
+        <p>Getting Service Metrics</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/metrics</code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -505,11 +505,11 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
   </div>
 
   <div class="index-row">
-    <h3><a href="entry/notification-groups">Notification groups</a></h3>
+    <h3><a href="entry/notification-groups">Notification Groups</a></h3>
     <div class="apis">
       <div class="api">
         <a href="entry/notification-groups#create">
-          <p>Register notification groups</p>
+          <p>Registering Notification Groups</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/notification-groups</code>
@@ -518,7 +518,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/notification-groups#get">
-          <p>Get notification group list</p>
+          <p>Getting Notification Groups</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/notification-groups</code>
@@ -527,7 +527,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/notification-groups#update">
-          <p>Update notification groups</p>
+          <p>Updating Notification Groups</p>
           <p class="type-put">
             <code>PUT</code>
             <code>/api/v0/notification-groups/<em>&lt;notificationGroupId&gt;</em></code>
@@ -536,7 +536,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/notification-groups#delete">
-          <p>Delete notification groups</p>
+          <p>Deleting Notification Groups</p>
           <p class="type-delete">
             <code>DELETE</code>
             <code>/api/v0/notification-groups/<em>&lt;notificationGroupId&gt;</em></code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -744,7 +744,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
     <div class="apis">
       <div class="api">
         <a href="entry/invitations#list">
-          <p>List of invitations</p>
+          <p>Listing Invitations</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/invitations</code>
@@ -753,7 +753,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/invitations#create">
-          <p>Creating an invitation</p>
+          <p>Creating Invitations</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/invitations</code>
@@ -762,7 +762,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/invitations#revoke">
-          <p>Cancelling an invitation</p>
+          <p>Cancelling Invitations</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/invitations/revoke</code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -383,7 +383,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
     <div class="apis">
       <div class="api">
         <a href="entry/monitors#create">
-          <p>Register monitor configurations</p>
+          <p>Registering Monitor Configurations</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/monitors</code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -571,11 +571,11 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
   </div>
 
   <div class="index-row">
-    <h3><a href="entry/alert-group-settings">Alert group settings</a></h3>
+    <h3><a href="entry/alert-group-settings">Alert Group Settings</a></h3>
     <div class="apis">
       <div class="api">
         <a href="entry/alert-group-settings#list">
-          <p>Listing alert group settings</p>
+          <p>Listing Alert Group Settings</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/alert-group-settings</code>
@@ -584,7 +584,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/alert-group-settings#create">
-          <p>Creating alert group settings</p>
+          <p>Creating Alert Group Settings</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/alert-group-settings</code>
@@ -593,7 +593,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/alert-group-settings#get">
-          <p>Getting alert group settings</p>
+          <p>Getting Alert Group Settings</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/alert-group-settings/<em>&lt;alertGroupSettingId&gt;</em></code>
@@ -602,7 +602,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/alert-group-settings#update">
-          <p>Updating alert group settings</p>
+          <p>Updating Alert Group Settings</p>
           <p class="type-put">
             <code>PUT</code>
             <code>/api/v0/alert-group-settings/<em>&lt;alertGroupSettingId&gt;</em></code>
@@ -611,7 +611,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/alert-group-settings#delete">
-          <p>Deleting alert group settings</p>
+          <p>Deleting Alert Group Settings</p>
           <p class="type-delete">
             <code>DELETE</code>
             <code>/api/v0/alert-group-settings/<em>&lt;alertGroupSettingId&gt;</em></code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -662,7 +662,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/dashboards#list">
-          <p>List of Dashboards</p>
+          <p>Listing Dashboards</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/dashboards</code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -41,7 +41,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
     <div class="apis">
       <div class="api">
         <a href="entry/services#list">
-          <p>List of Services</p>
+          <p>Listing Services</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/services</code>
@@ -50,7 +50,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/services#create">
-          <p>Register Services</p>
+          <p>Registering Services</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/services</code>
@@ -59,7 +59,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>      
       <div class="api">
         <a href="entry/services#delete">
-          <p>Delete Services</p>
+          <p>Deleting Services</p>
           <p class="type-delete">
             <code>DELETE</code>
             <code>/api/v0/services/<em>&lt;serviceName&gt;</em></code>
@@ -68,7 +68,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/services#rolelist">
-          <p>List of Roles</p>
+          <p>Listing Roles</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/roles</code>
@@ -77,7 +77,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/services#rolecreate">
-          <p>Register roles</p>
+          <p>Registering Roles</p>
           <p class="type-post">
               <code>POST</code>
               <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/roles</code>
@@ -86,7 +86,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/services#roledelete">
-          <p>Delete roles</p>
+          <p>Deleting Roles</p>
           <p class="type-delete">
               <code>DELETE</code>
               <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/roles/<em>&lt;roleName&gt;</em></code>
@@ -95,7 +95,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/services#metric-names">
-          <p>List of metric names</p>
+          <p>Listing Metric Names</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/services/<em>&lt;serviceName&gt;</em>/metric-names</code>

--- a/content/api-docs/entry/index.md
+++ b/content/api-docs/entry/index.md
@@ -472,11 +472,11 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
   </div>
 
   <div class="index-row">
-    <h3><a href="entry/channels">Notification channels</a></h3>
+    <h3><a href="entry/channels">Notification Channels</a></h3>
     <div class="apis">
       <div class="api">
         <a href="entry/channels#get">
-          <p>Get notification channel list</p>
+          <p>Getting Notification Channels</p>
           <p class="type-get">
             <code>GET</code>
             <code>/api/v0/channels</code>
@@ -485,7 +485,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/channels#create">
-          <p>Register notification channels</p>
+          <p>Registering Notification Channels</p>
           <p class="type-post">
             <code>POST</code>
             <code>/api/v0/channels</code>
@@ -494,7 +494,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
       </div>
       <div class="api">
         <a href="entry/channels#delete">
-          <p>Delete notification channels</p>
+          <p>Deleting Notification Channels</p>
           <p class="type-delete">
             <code>DELETE</code>
             <code>/api/v0/channels/<em>&lt;channelId&gt;</em></code>

--- a/content/api-docs/entry/invitations.md
+++ b/content/api-docs/entry/invitations.md
@@ -6,13 +6,13 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 ---
 
 <ul class="internal-nav">
-  <li><a href="#list">List of invitations</a></li>
-  <li><a href="#create">Creating an invitation</a></li>
-  <li><a href="#revoke">Cancelling an invitation</a></li>
+  <li><a href="#list">Listing Invitations</a></li>
+  <li><a href="#create">Creating Invitations</a></li>
+  <li><a href="#revoke">Cancelling Invitations</a></li>
 </ul>
 
 
-<h2 id="list">List of invitations</h2>
+<h2 id="list">Listing Invitations</h2>
 
 <p class="type-get">
   <code>GET</code>
@@ -44,7 +44,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 | `expiresAt` | *number* | the expiration date of the invitation (in epoch seconds)                                    |
 
 
-<h2 id="create">Creating an invitation</h2>
+<h2 id="create">Creating Invitations</h2>
 
 Specify an email address and permission and invite a user to the organization.
 
@@ -110,7 +110,7 @@ The expiresAt field (in epoch seconds) is given and returned with the input. Inv
   </tbody>
 </table>
 
-<h2 id="revoke">Cancelling an invitation</h2>
+<h2 id="revoke">Cancelling Invitations</h2>
 
 Specify the email address and cancel an invitation to the organization.
 

--- a/content/api-docs/entry/metadata.md
+++ b/content/api-docs/entry/metadata.md
@@ -9,7 +9,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
   <li><a href="#hostget">Getting Host Metadata</a></li>
   <li><a href="#hostput">Registering/Updating Host Metadata</a></li>
   <li><a href="#hostdelete">Deleting Host Metadata</a></li>
-  <li><a href="#hostlist">List of host metadata</a></li>
+  <li><a href="#hostlist">Listing Host Metadata</a></li>
   <li><a href="#serviceget">Getting Service Metadata</a></li>
   <li><a href="#serviceput">Registering/Updating Service Metadata</a></li>
   <li><a href="#servicedelete">Deleting Service Metadata</a></li>

--- a/content/api-docs/entry/metadata.md
+++ b/content/api-docs/entry/metadata.md
@@ -6,18 +6,18 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 ---
 
 <ul class="internal-nav">
-  <li><a href="#hostget">Get host metadata</a></li>
-  <li><a href="#hostput">Register/Update host metadata</a></li>
-  <li><a href="#hostdelete">Delete host metadata</a></li>
+  <li><a href="#hostget">Getting Host Metadata</a></li>
+  <li><a href="#hostput">Registering/Updating Host Metadata</a></li>
+  <li><a href="#hostdelete">Deleting Host Metadata</a></li>
   <li><a href="#hostlist">List of host metadata</a></li>
-  <li><a href="#serviceget">Get service metadata</a></li>
-  <li><a href="#serviceput">Register/Update service metadata</a></li>
-  <li><a href="#servicedelete">Delete service metadata</a></li>
-  <li><a href="#servicelist">List of service metadata</a></li>
-  <li><a href="#roleget">Get role metadata</a></li>
-  <li><a href="#roleput">Register/Update role metadata</a></li>
-  <li><a href="#roledelete">Delete role metadata</a></li>
-  <li><a href="#rolelist">List of role metadata</a></li>
+  <li><a href="#serviceget">Getting Service Metadata</a></li>
+  <li><a href="#serviceput">Registering/Updating Service Metadata</a></li>
+  <li><a href="#servicedelete">Deleting Service Metadata</a></li>
+  <li><a href="#servicelist">Listing Service Metadata</a></li>
+  <li><a href="#roleget">Getting Role Metadata</a></li>
+  <li><a href="#roleput">Registering/Updating Role Metadata</a></li>
+  <li><a href="#roledelete">Deleting Role Metadata</a></li>
+  <li><a href="#rolelist">Listing Role Metadata</a></li>
 </ul>
 
 <h2 id="metadata">Metadata</h2>
@@ -41,7 +41,7 @@ You can obtain and register JSON (object, array, string, number, boolean, null) 
 
 Numeric characters,` _`, and `-` can be used with letters of the alphabet (`[-a-zA-Z0-9_]+`). However, a namespace that begins with `mackerel` will be used by the Mackerel system. 
 
-<h2 id="hostget">Get host metadata</h2>
+<h2 id="hostget">Getting Host Metadata</h2>
 
 Obtain registered metadata.
 
@@ -85,7 +85,7 @@ JSON of the registered data is returned. The date and time of metadata’s last 
   </tbody>
 </table>
 
-<h2 id="hostput">Register/Update host metadata</h2>
+<h2 id="hostput">Registering/Updating Host Metadata</h2>
 
 Create and update arbitrary JSON as metadata of the host.
 
@@ -150,7 +150,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
   </tbody>
 </table>
 
-<h2 id="hostdelete">Delete host metadata</h2>
+<h2 id="hostdelete">Deleting Host Metadata</h2>
 
 <p class="type-delete">
   <code>DELETE</code>
@@ -203,7 +203,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
   </tbody>
 </table>
 
-<h2 id="hostlist">List host metadata</h2>
+<h2 id="hostlist">Listing Host Metadata</h2>
 
 <p class="type-get">
   <code>GET</code>
@@ -266,7 +266,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
   </tbody>
 </table>
 
-<h2 id="serviceget">Get service metadata</h2>
+<h2 id="serviceget">Getting Service Metadata</h2>
 
 Obtain registered metadata.
 
@@ -306,7 +306,7 @@ JSON of the registered data is returned. The date and time of metadata’s last 
   </tbody>
 </table>
 
-<h2 id="serviceput">Register/Update service metadata</h2>
+<h2 id="serviceput">Registering/Updating Service Metadata</h2>
 
 Create and update arbitrary JSON as metadata of the service.
 
@@ -367,7 +367,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
   </tbody>
 </table>
 
-<h2 id="servicedelete">Delete service metadata</h2>
+<h2 id="servicedelete">Deleting Service Metadata</h2>
 
 <p class="type-delete">
   <code>DELETE</code>
@@ -416,7 +416,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
   </tbody>
 </table>
 
-<h2 id="servicelist">List of service metadata</h2>
+<h2 id="servicelist">Listing Service Metadata</h2>
 
 <p class="type-get">
   <code>GET</code>
@@ -475,7 +475,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
   </tbody>
 </table>
 
-<h2 id="roleget">Get role metadata</h2>
+<h2 id="roleget">Getting Role Metadata</h2>
 
 Obtain registered metadata.
 
@@ -515,7 +515,7 @@ JSON of the registered data is returned. The date and time of metadata’s last 
   </tbody>
 </table>
 
-<h2 id="roleput">Register/Update role metadata</h2>
+<h2 id="roleput">Registering/Updating Role Metadata</h2>
 
 Create and update arbitrary JSON as metadata of the role.
 
@@ -576,7 +576,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
   </tbody>
 </table>
 
-<h2 id="roledelete">Delete role metadata</h2>
+<h2 id="roledelete">Deleting Role Metadata</h2>
 
 <p class="type-delete">
   <code>DELETE</code>
@@ -625,7 +625,7 @@ Any JSON can be specified. However, the size of the data is limited to 100KB.
   </tbody>
 </table>
 
-<h2 id="rolelist">List of role metadata</h2>
+<h2 id="rolelist">Listing Role Metadata</h2>
 
 <p class="type-get">
   <code>GET</code>

--- a/content/api-docs/entry/monitors.md
+++ b/content/api-docs/entry/monitors.md
@@ -6,7 +6,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 ---
 
 <ul class="internal-nav">
-  <li><a href="#create">Register monitor configurations</a></li>
+  <li><a href="#create">Registering Monitor Configurations</a></li>
   <li><a href="#list">Listing Monitor Configurations</a></li>
   <li><a href="#get">Getting Monitor Configurations</a></li>
   <li><a href="#update">Updating Monitor Configurations</a></li>
@@ -14,7 +14,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 </ul>
 
 
-<h2 id="create">Register monitor configurations</h2>
+<h2 id="create">Registering Monitor Configurations</h2>
 
 Monitors for various types of metrics as well as external monitors will be registered with Mackerel.
 The input procedure varies depending on the monitoring target.
@@ -848,7 +848,7 @@ When `scopes` and `excludeScopes` are updated, the JSON which was designated wil
 
 #### Success
 
-The updated monitoring configurations are returned. The same format as [Register monitor configurations](#create).
+The updated monitoring configurations are returned. The same format as [Registering Monitor Configurations](#create).
 
 #### Error
 

--- a/content/api-docs/entry/monitors.md
+++ b/content/api-docs/entry/monitors.md
@@ -7,10 +7,10 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 
 <ul class="internal-nav">
   <li><a href="#create">Register monitor configurations</a></li>
-  <li><a href="#list">List of monitor configurations</a></li>
-  <li><a href="#get">Get monitor configurations</a></li>
-  <li><a href="#update">Update monitor configurations</a></li>
-  <li><a href="#delete">Delete monitor configurations</a></li>
+  <li><a href="#list">Listing Monitor Configurations</a></li>
+  <li><a href="#get">Getting Monitor Configurations</a></li>
+  <li><a href="#update">Updating Monitor Configurations</a></li>
+  <li><a href="#delete">Deleting Monitor Configurations</a></li>
 </ul>
 
 
@@ -602,7 +602,7 @@ In order to monitor response time, it's necessary to assign `responseTimeWarning
 
 ----------------------------------------------
 
-<h2 id="list">List of monitor configurations</h2>
+<h2 id="list">Listing Monitor Configurations</h2>
 
 <p class="type-get">
   <code>GET</code>
@@ -785,7 +785,7 @@ In order to monitor response time, it's necessary to assign `responseTimeWarning
 
 ----------------------------------------------
 
-<h2 id="get">Get monitor configurations</h2>
+<h2 id="get">Getting Monitor Configurations</h2>
 
 <p class="type-get">
   <code>GET</code>
@@ -827,7 +827,7 @@ In order to monitor response time, it's necessary to assign `responseTimeWarning
 
 ----------------------------------------------
 
-<h2 id="update">Update monitor configurations</h2>
+<h2 id="update">Updating Monitor Configurations</h2>
 
 <p class="type-put">
   <code>PUT</code>
@@ -887,7 +887,7 @@ same errors as when [creating](#create).
 
 ----------------------------------------------
 
-<h2 id="delete">Delete monitor configurations</h2>
+<h2 id="delete">Deleting Monitor Configurations</h2>
 
 <p class="type-delete">
   <code>DELETE</code>

--- a/content/api-docs/entry/notification-groups.md
+++ b/content/api-docs/entry/notification-groups.md
@@ -6,14 +6,14 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 ---
 
 <ul class="internal-nav">
-  <li><a href="#create">Register notification groups</a></li>
-  <li><a href="#get">Get notification group list</a></li>
-  <li><a href="#update">Update notification groups</a></li>
-  <li><a href="#delete">Delete notification groups</a></li>
+  <li><a href="#create">Registering Notification Groups</a></li>
+  <li><a href="#get">Getting Notification Groups</a></li>
+  <li><a href="#update">Updating Notification Groups</a></li>
+  <li><a href="#delete">Deleting Notification Groups</a></li>
 </ul>
 
 
-<h2 id="create">Register notification groups</h2>
+<h2 id="create">Registering Notification Groups</h2>
 
 <p class="type-post">
   <code>POST</code>
@@ -129,7 +129,7 @@ The input is returned along with an ID.
 
 `<notification-group>` is the same as the registration API response
 
-<h2 id="update">Update notification groups</h2>
+<h2 id="update">Updating Notification Groups</h2>
 
 <p class="type-put">
   <code>PUT</code>
@@ -184,7 +184,7 @@ The same object as registration API response
   </tbody>
 </table>
 
-<h2 id="delete">Delete notification groups</h2>
+<h2 id="delete">Deleting Notification Groups</h2>
 The organization’s default notification group can not be deleted
 
 <p class="type-delete">

--- a/content/api-docs/entry/organizations.md
+++ b/content/api-docs/entry/organizations.md
@@ -5,7 +5,7 @@ URL: https://mackerel.io/api-docs/entry/organizations
 EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel.io/atom/entry/10328537792368377880
 ---
 
-<h2 id="get">Get the information of the organization</h2>
+<h2 id="get">Getting Organization Information</h2>
 
 This will get the information of the organization.
 

--- a/content/api-docs/entry/service-metrics.md
+++ b/content/api-docs/entry/service-metrics.md
@@ -7,7 +7,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 
 <ul class="internal-nav">
   <li><a href="#post">Posting Service Metrics</a></li>
-  <li><a href="#get">Getting service metrics</a></li>
+  <li><a href="#get">Getting Service Metrics</a></li>
 </ul>
 
 
@@ -80,7 +80,7 @@ If old values are being transmitted to the API, the values on the Mackerel inter
 
 ----------------------------------------------
 
-<h2 id="get">Getting service metrics</h2>
+<h2 id="get">Getting Service Metrics</h2>
 
 This will get metric values connected to services.
 

--- a/content/api-docs/entry/services.md
+++ b/content/api-docs/entry/services.md
@@ -6,16 +6,16 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 ---
 
 <ul class="internal-nav">
-  <li><a href="#list">List of Services</a></li>
-  <li><a href="#create">Register Services</a></li>
-  <li><a href="#delete">Delete Services</a></li>
-  <li><a href="#rolelist">List of Roles</a></li>
-  <li><a href="#rolecreate">Register Roles</a></li>
-  <li><a href="#roledelete">Delete Roles</a></li>
-  <li><a href="#metric-names">List of metric names</a></li>
+  <li><a href="#list">Listing Services</a></li>
+  <li><a href="#create">Registering Services</a></li>
+  <li><a href="#delete">Deleting Services</a></li>
+  <li><a href="#rolelist">Listing Roles</a></li>
+  <li><a href="#rolecreate">Registering Roles</a></li>
+  <li><a href="#roledelete">Deleting Roles</a></li>
+  <li><a href="#metric-names">Listing Metric Names</a></li>
 </ul>
 
-<h2 id="list">List of Services</h2>
+<h2 id="list">Listing Services</h2>
 
 <p class="type-get">
   <code>GET</code>
@@ -48,7 +48,7 @@ Arrays will be shown in the order of Role names.
 
 ----------------------------------------------
 
-<h2 id="create">Register Services</h2>
+<h2 id="create">Registering Services</h2>
 
 <p class="type-post">
   <code>POST</code>
@@ -126,7 +126,7 @@ The created service will be returned. The format will be the same as <i>`<servic
 
 ----------------------------------------------
 
-<h2 id="delete">Delete Services</h2>
+<h2 id="delete">Deleting Services</h2>
 
 <p class="type-delete">
   <code>DELETE</code>
@@ -186,7 +186,7 @@ Arrays will be shown in the order of Role names.
 
 ----------------------------------------------
 
-<h2 id="rolelist">List of Roles</h2>
+<h2 id="rolelist">Listing Roles</h2>
 
 <p class="type-get">
   <code>GET</code>
@@ -238,7 +238,7 @@ Arrays will be shown in the order of Role names.
 
 ----------------------------------------------
 
-<h2 id="rolecreate">Register Roles</h2>
+<h2 id="rolecreate">Registering Roles</h2>
  
 <p class="type-post">
   <code>POST</code>
@@ -319,7 +319,7 @@ The created role will be returned. The format will be the same as <i>`<role>`</i
 
 ----------------------------------------------
 
-<h2 id="roledelete">Delete Roles</h2>
+<h2 id="roledelete">Deleting Roles</h2>
 
 <p class="type-delete">
   <code>DELETE</code>
@@ -373,7 +373,7 @@ The state of the role just before being deleted will be returned.
 
 ----------------------------------------------
 
-<h2 id="metric-names">List of metric names</h2>
+<h2 id="metric-names">Listing Metric Names</h2>
 
 <p class="type-get">
   <code>GET</code>

--- a/content/api-docs/entry/users.md
+++ b/content/api-docs/entry/users.md
@@ -6,12 +6,12 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api.hatenablog.mackerel
 ---
 
 <ul class="internal-nav">
-  <li><a href="#list">List of users</a></li>
-  <li><a href="#delete">Delete users</a></li>
+  <li><a href="#list">Listing Users</a></li>
+  <li><a href="#delete">Deleting Users</a></li>
 </ul>
 
 
-<h2 id="list">List of users</h2>
+<h2 id="list">Listing Users</h2>
 
 This will get a list of the users belonging to an organization.
 
@@ -49,7 +49,7 @@ This will get a list of the users belonging to an organization.
 
 ----------------------------------------------
 
-<h2 id="delete">Delete users</h2>
+<h2 id="delete">Deleting Users</h2>
 
 This will delete users belonging to an organization.
 

--- a/content/docs/entry/advanced/custom-metrics.md
+++ b/content/docs/entry/advanced/custom-metrics.md
@@ -122,7 +122,7 @@ Metric definitions contain the following items:
 
 | Key | Description |
 | ---- | ---- | 
-| `name` | Specifies that this definition corresponds to custom metric {graph}.{name} . {name} cannot contain dots (`.`). Any alphanumeric characters, hyphen (`-`), or underscore (`_`) can be used（/[-a-zA-Z0-9_]/）. Additionally, wildcard characters (`*` and `#`) can also be used. For more details, refer to the [API specs (v0) / Posting graph definitions help page.](https://mackerel.io/api-docs/entry/host-metrics#post-graphdef)| 
+| `name` | Specifies that this definition corresponds to custom metric {graph}.{name} . {name} cannot contain dots (`.`). Any alphanumeric characters, hyphen (`-`), or underscore (`_`) can be used（/[-a-zA-Z0-9_]/）. Additionally, wildcard characters (`*` and `#`) can also be used. For more details, refer to the [API specs (v0) / Posting Graph Definitions help page.](https://mackerel.io/api-docs/entry/host-metrics#post-graphdef)| 
 | `label` | The label of the series corresponding to custom metric {graph}.{name} . | 
 | `stacked` | Indicates whether or not the series of custom metrics {graph}.{name} is in stacked display mode. If false it will be displayed in line segment mode. |
 


### PR DESCRIPTION
## What I have done
- Some headers are in the form, `List of...` , or `Get list of ...`, and others are in the form, `Listing ...`
  - I prefer the latter so I am going through the API list and replacing the titles to make them consistent.

For headers I mean here,
https://mackerel.io/api-docs/

<img width="387" alt="スクリーンショット 2020-01-06 22 52 18" src="https://user-images.githubusercontent.com/3520520/71822069-3d229580-30d7-11ea-9a98-5c6c11f920ab.png">

And here (the individual pages)
https://mackerel.io/api-docs/entry/services
<img width="731" alt="スクリーンショット 2020-01-06 22 52 30" src="https://user-images.githubusercontent.com/3520520/71822088-4b70b180-30d7-11ea-95ba-2d22eb171e86.png">

## Reviewing the Pull Request
- The diff is kind of big (sorry), so maybe it is easier to check the diff for each commit.