### PR TITLE
once of mackerel-agent is a subcommand

### DIFF
--- a/content/docs/entry/spec/agent.md
+++ b/content/docs/entry/spec/agent.md
@@ -248,7 +248,6 @@ The following startup options can be specified. If the same items are specified 
 - `-pidfile=/var/run/mackerel-agent.pid` This is the PID file path.
 - `-root=/var/lib/mackerel-agent` This is the path of the directory where the status of the mackerel-agent is recorded. Currently only the ID file that identifies the host will be placed here.
 - `-role=<service>:<role>` This designates the roles and services a role is assigned to.
-- `-once` this will execute metric collection and display standard output just one time. Metrics will not be posted.
 - `-diagnostic` metrics for the agent itself will be collected and posted.
 
 <h2 id="faq">FAQ</h2>
@@ -286,6 +285,14 @@ mackerel-agent configtest
 
 Check the syntax of the configuration file (`mackerel-agent.conf`).
 
+
+### once
+
+```
+mackerel-agent once
+```
+
+This will execute metric collection and display standard output just one time. Metrics will not be posted.
 
 ## Settings file for init script
 

--- a/content/ja/docs/entry/spec/agent.md
+++ b/content/ja/docs/entry/spec/agent.md
@@ -248,7 +248,6 @@ use_mountpoint = true
 - `-pidfile=/var/run/mackerel-agent.pid` PIDファイルへのパスです。
 - `-root=/var/lib/mackerel-agent` mackerel-agentの状態を記録するディレクトリへのパスです。現在はホストを識別するidファイルのみが置かれます。
 - `-role=<service>:<role>` ホストに割り当てるロールおよびサービスを指定します。
-- `-once` 一度だけメトリックの収集を実行して標準出力に表示します。投稿は行われません。
 - `-diagnostic` エージェント自身のメトリックを収集して投稿します。
 
 <h2 id="faq">FAQ</h2>
@@ -285,6 +284,14 @@ mackerel-agent configtest
 ```
 
 設定ファイル（ `mackerel-agent.conf` ）のシンタックスチェックをおこなえます。
+
+### once
+
+```
+mackerel-agent once
+```
+
+一度だけメトリックの収集を実行して標準出力に表示します。投稿は行われません。
 
 ## initスクリプト用設定ファイル
 


### PR DESCRIPTION
`once` of mackerel-agent is a subcommand, not an option.

ref. https://github.com/mackerelio/mackerel-agent/blob/711cd82e4457ad99a4a5145a0e87ee8c262941ea/commands_gen.go#L62-L69
