### PR TITLE
Standardize grammar, 'Name' to 'name'

### DIFF
--- a/content/ja/docs/entry/advanced/monitors-github.md
+++ b/content/ja/docs/entry/advanced/monitors-github.md
@@ -188,7 +188,7 @@ mkr monitors では monitor rule の特定に`id`もしくは`name`を利用し�
   ```
   mkr monitors push
   ```
-  - `Name`ベースで監視ルールの同一判定をするため、`id`反映のためのpullは不要となります
+  - `name`ベースで監視ルールの同一判定をするため、`id`反映のためのpullは不要となります
 
 ### Mackerel側のルールを反映する
 


### PR DESCRIPTION
## What I have done

Fix `Name` to `name`, like the others in the file.
(Uppercase is used here only one time.)