### PR TITLE
Fix monitor API documents to mark thresholds to be optional

### DIFF
--- a/content/api-docs/entry/monitors.md
+++ b/content/api-docs/entry/monitors.md
@@ -50,15 +50,15 @@ The input procedure varies depending on the monitoring target.
 | `name`          | *string*   | arbitrary name that can be referenced from the monitors list, etc. |
 | `memo`          | *string*   | [optional] notes for the monitoring configuration |
 | `duration`      | *number*   | average value of the designated interval (in minutes) will be monitored. valid interval (1 to 10 min.) |
-| `metric`        | *string*   | name of the host metric targeted by monitoring. by designating a specific constant string, comparative monitoring is possible [*1](#comparative-monitoring) | 
-| `operator`      | *string*   | determines the conditions that state whether the designated variable is either big or small. the observed value is on the left of `”>”` or `”<”` and the designated value is on the right | 
-| `warning`       | *number*   | the threshold that generates a warning alert. comparative monitoring has a valid range of 1-100[*1](#comparative-monitoring) |
-| `critical`      | *number*   | the threshold that generates a critical alert. comparative monitoring has a valid range of 1-100[*1](#comparative-monitoring) |
+| `metric`        | *string*   | name of the host metric targeted by monitoring. by designating a specific constant string, comparative monitoring is possible [*1](#comparative-monitoring) |
+| `operator`      | *string*   | determines the conditions that state whether the designated variable is either big or small. the observed value is on the left of `”>”` or `”<”` and the designated value is on the right |
+| `warning`       | *number*   | [optional] the threshold that generates a warning alert. comparative monitoring has a valid range of 1-100[*1](#comparative-monitoring) |
+| `critical`      | *number*   | [optional] the threshold that generates a critical alert. comparative monitoring has a valid range of 1-100[*1](#comparative-monitoring) |
 | `maxCheckAttempts`           | *number*   | [optional] number of consecutive Warning/Critical instances before an alert is made. Default setting is 1 (1-10) |
 | `notificationInterval`       | *number*   | [optional] the time interval (in minutes) for re-sending notifications. If this field is omitted, notifications will not be re-sent. |
-| `scopes`        | *array[string]* | [optional] monitoring target’s service name or role details name  [*2](#service-name) | 
-| `excludeScopes` | *array[string]* | [optional] monitoring exclusion target’s service name or role details name  [*2](#service-name) | 
-| `isMute` | *boolean* | [optional] Whether monitoring is muted or not [*3](#muted-monitoring) | 
+| `scopes`        | *array[string]* | [optional] monitoring target’s service name or role details name  [*2](#service-name) |
+| `excludeScopes` | *array[string]* | [optional] monitoring exclusion target’s service name or role details name  [*2](#service-name) |
+| `isMute` | *boolean* | [optional] Whether monitoring is muted or not [*3](#muted-monitoring) |
 
 
 ##### Example Input
@@ -301,13 +301,13 @@ This function disables notifications in monitoring. Alerts occur in response to 
 | `duration`      | *number*   | monitors the average value of the designated number of points. range: most recent 1~10 points |
 | `metric`        | *string*   | name of the monitoring target’s host metric name |
 | `operator`      | *string*   | determines the conditions that state whether the designated variable is either big or small. the observed value is on the left of `”>”` or `”<”` and the designated value is on the right |
-| `warning`       | *number*   | the threshold that generates a warning alert |
-| `critical`      | *number*   | the threshold that generates a critical alert |
+| `warning`       | *number*   | [optional] the threshold that generates a warning alert |
+| `critical`      | *number*   | [optional] the threshold that generates a critical alert |
 | `maxCheckAttempts`          | *number*   | [optional] number of consecutive Warning/Critical instances before an alert is made. Default setting is 1 (1-10) |
 | `missingDurationWarning`    | *number*   | [optional] the threshold (in minutes) to generate a warning alert for interruption monitoring                                                                |
 | `missingDurationCritical`   | *number*   | [optional] the threshold (in minutes) to generate a critical alert for interruption monitoring                                                                |
 | `notificationInterval`      | *number*   | [optional] the time interval (in minutes) for re-sending notifications. If this field is omitted, notifications will not be re-sent. |
-| `isMute` | *boolean* | [optional] Whether monitoring is muted or not [*3](#muted-monitoring) | 
+| `isMute` | *boolean* | [optional] Whether monitoring is muted or not [*3](#muted-monitoring) |
 
 ##### Example Input
 
@@ -411,15 +411,15 @@ This function disables notifications in monitoring. Alerts occur in response to 
 | ---------------------- | ---------- | -------------------------------- |
 | `type`                 | *string*   | constant string `"external"`          |
 | `name`                 | *string*   | arbitrary name that can be referenced from the monitors list, etc. |
-| `memo`                            | *string*   | [optional] notes for the monitoring configuration |
+| `memo`                 | *string*   | [optional] notes for the monitoring configuration |
 | `url`                  | *string*   | monitoring target URL |
 | `method`               | *string*   | [optional] request method, one of `GET`, `POST`, `PUT`, `DELETE`. If omitted, `GET` method is used. |
 | `service`              | *string*   | [optional] service name (when response time is monitored, it will be graphed in the service metrics of the service linked here) |
 | `notificationInterval` | *number*   | [optional] the time interval (in minutes) for re-sending notifications. If this field is omitted, notifications will not be re-sent. |
 | `responseTimeWarning`  | *number*   | [optional] the response time threshold for Warning alerts (in milliseconds) `service` designation is required|
 | `responseTimeCritical` | *number*   | [optional] the response time threshold for Critical alerts (in milliseconds) `service` designation is required |
-| `responseTimeDuration` | *number*   | [optional] will monitor the avg. value of requests in the designated time frame (1-10 min.). `service` designation is required |  
-| `containsString`       | *string*   | [optional] string which should be contained by the response body |  
+| `responseTimeDuration` | *number*   | [optional] will monitor the avg. value of requests in the designated time frame (1-10 min.). `service` designation is required |
+| `containsString`       | *string*   | [optional] string which should be contained by the response body |
 | `maxCheckAttempts`     | *number*   | [optional] number of consecutive Warning/Critical instances before an alert is made. Default setting is 1 (1-10) |
 | `certificationExpirationWarning`    | *number*   | [optional] certification expiration date monitor’s “Warning” threshold. number of days remaining until expiration. |
 | `certificationExpirationCritical`   | *number*   | [optional] certification expiration date monitor’s “Critical” threshold. number of days remaining until expiration. |
@@ -429,7 +429,8 @@ This function disables notifications in monitoring. Alerts occur in response to 
 | `requestBody`          | *string*   | [optional] HTTP request body |
 | `followRedirect` | *boolean* | [optional] Evaluates the response of the redirector as a result. If this field is omitted, the redirection destination in the response will not be tracked. |
 
-In order to monitor response time, it's necessary to assign `responseTimeWarning`, `responseTimeCritical`, and `responseTimeDuration`. . In order to monitor the certification expiration date, it’s necessary to assign both `certificationExpirationWarning`, and `certificationExpirationCritical`.
+In order to monitor response time, it's necessary to specify `responseTimeDuration` and at least one of `responseTimeWarning` and `responseTimeCritical`.
+In order to monitor the certification expiration date, it’s necessary to specify at least one of `certificationExpirationWarning` and `certificationExpirationCritical`.
 
 ##### Example Input
 
@@ -536,8 +537,8 @@ In order to monitor response time, it's necessary to assign `responseTimeWarning
 | `memo`          | *string*   | [optional] notes for the monitoring configuration |
 | `expression`    | *string*   | Expression of the monitoring target. Only valid for graph sequences that become one line. |
 | `operator`      | *string*   | determines the conditions that state whether the designated variable is either big or small. the observed value is on the left of ”>”or ”<” and the designated value is on the right|
-| `warning`       | *number*   | the threshold that generates a warning alert |
-| `critical`      | *number*   | the threshold that generates a critical alert |
+| `warning`       | *number*   | [optional] the threshold that generates a warning alert |
+| `critical`      | *number*   | [optional] the threshold that generates a critical alert |
 | `notificationInterval` | *number* | [optional] The time interval (in minutes) for re-sending notifications. If this field is omitted, notifications will not be re-sent. |
 | `isMute`        | *boolean*       | [optional] whether monitoring is muted or not  [*3](#mute) |
 
@@ -709,13 +710,13 @@ In order to monitor response time, it's necessary to assign `responseTimeWarning
 | `type`          | *string*   | constant string `"anomalyDetection"`               |
 | `name`          | *string*   | arbitrary name that can be referenced from the monitors list, etc. |
 | `memo`          | *string*   | [optional] notes for the monitoring configuration |
-| `scopes`        | *array[string]* | [optional] monitoring target’s service name and role details name  [*2](#service-name) | 
-| `warningSensitivity`       | *string*   | the sensitivity (`insensitive`, `normal`, or `sensitive`) that generates warning alerts. |
-| `criticalSensitivity`       | *string*   | the sensitivity (`insensitive`, `normal`, or `sensitive`) that generates critical alerts. |
-| `maxCheckAttempts`           | *number*   | [optional] number of consecutive Warning/Critical instances before an alert is made. Default setting is 3 (1-10) |
-| `trainingPeriodFrom`     | *number* | [optional] Specified training period (Uses metric data starting from the specified time) |
-| `notificationInterval` | *number* | [optional] the time interval (in minutes) for re-sending notifications. If this field is omitted, notifications will not be re-sent. |
-| `isMute`        | *boolean*       | [optional] whether monitoring is muted or not |
+| `scopes`        | *array[string]* | [optional] monitoring target’s service name and role details name  [*2](#service-name) |
+| `warningSensitivity`   | *string*  | [optional] the sensitivity (`insensitive`, `normal`, or `sensitive`) that generates warning alerts. |
+| `criticalSensitivity`  | *string*  | [optional] the sensitivity (`insensitive`, `normal`, or `sensitive`) that generates critical alerts. |
+| `maxCheckAttempts`     | *number*  | [optional] number of consecutive Warning/Critical instances before an alert is made. Default setting is 3 (1-10) |
+| `trainingPeriodFrom`   | *number*  | [optional] Specified training period (Uses metric data starting from the specified time) |
+| `notificationInterval` | *number*  | [optional] the time interval (in minutes) for re-sending notifications. If this field is omitted, notifications will not be re-sent. |
+| `isMute`               | *boolean* | [optional] whether monitoring is muted or not |
 
 ##### Example Input
 
@@ -784,6 +785,10 @@ In order to monitor response time, it's necessary to assign `responseTimeWarning
     </tr>
     <tr>
       <td>400</td>
+      <td>when the both <code>warningSensitivity</code> or <code>criticalSensitivity</code> are unspecified</td>
+    </tr>
+    <tr>
+      <td>400</td>
       <td>when the notification re-sending time interval is not set at 10 minutes or more</td>
     </tr>
     <tr>
@@ -849,7 +854,7 @@ In order to monitor response time, it's necessary to assign `responseTimeWarning
 </p>
 
 As for requests and responses, just as when [create monitors](#create), every field must be specified. If there are any insufficient items that are required, an error will be generated.
-When `scopes` and `excludeScopes` are updated, the JSON which was designated will be completely overwritten. For example, by omitting an item in `scopes` when it has already been saved, `scopes` will be deleted. 
+When `scopes` and `excludeScopes` are updated, the JSON which was designated will be completely overwritten. For example, by omitting an item in `scopes` when it has already been saved, `scopes` will be deleted.
 
 ### Connectivity Monitoring
 
@@ -857,7 +862,7 @@ When changing the `alertStatusOnGone` field, alerts generated by that monitor pr
 
 - Notifications configured to be resent (`notificationInterval`)
 
-    After `alertStatusOnGone` has been changed, only notifications that are configured for resending will change to the new alert status once resent. 
+    After `alertStatusOnGone` has been changed, only notifications that are configured for resending will change to the new alert status once resent.
 
 - Notifications not configured to be resent
 

--- a/content/ja/api-docs/entry/monitors.md
+++ b/content/ja/api-docs/entry/monitors.md
@@ -51,8 +51,8 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
 | `duration`      | *number*   | 指定された間隔(分)の平均値を監視します。有効範囲：1~10分。 |
 | `metric`        | *string*   | 監視対象のホストメトリック名。特定の定数文字列を指定することで、割合監視が可能です。 [*1](#comparative-monitoring) |
 | `operator`      | *string*   | 指定した数値より大きいか小さいかというアラート条件を指定。`">"` または `"<"`。左辺が観測値で右辺が設定値となります。|
-| `warning`       | *number*   | warningのAlert発生の閾値。割合監視 [*1](#comparative-monitoring) の場合は、有効範囲が0~100(%)になります。 |
-| `critical`      | *number*   | criticalのAlert発生の閾値。割合監視 [*1](#comparative-monitoring) の場合は、有効範囲が0~100(%)になります。 |
+| `warning`       | *number*   | [optional] warningのAlert発生の閾値。割合監視 [*1](#comparative-monitoring) の場合は、有効範囲が0~100(%)になります。 |
+| `critical`      | *number*   | [optional] criticalのAlert発生の閾値。割合監視 [*1](#comparative-monitoring) の場合は、有効範囲が0~100(%)になります。 |
 | `maxCheckAttempts`     | *number* | [optional] 何回連続で Warning/Critical になったらアラートを発生させるか。デフォルトは1 (1~10)です。 |
 | `notificationInterval` | *number* | [optional] 通知の再送設定をするときの再送間隔 (分)。このフィールドを省略すると通知は再送されません。 |
 | `scopes`        | *array[string]* | [optional] 監視対象のサービス名またはロール詳細名。[*2](#service-name)  |
@@ -298,8 +298,8 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
 | `duration`                | *number*  | 指定されたポイント数の平均値を監視する。有効範囲：直近1~10ポイント                                                   |
 | `metric`                  | *string*  | 監視対象のホストメトリック名。                                                                                       |
 | `operator`                | *string*  | 指定した数値より大きいか小さいかというアラート条件を指定。`">"` または `"<"`。左辺が観測値で右辺が設定値となります。 |
-| `warning`                 | *number*  | warningのAlert発生の閾値。                                                                                           |
-| `critical`                | *number*  | criticalのAlert発生の閾値。                                                                                          |
+| `warning`                 | *number*  | [optional] warningのAlert発生の閾値。                                                                                           |
+| `critical`                | *number*  | [optional] criticalのAlert発生の閾値。                                                                                          |
 | `maxCheckAttempts`        | *number*  | [optional] 何回連続で Warning/Critical になったらアラートを発生させるか。デフォルトは1 (1~10)です。                  |
 | `missingDurationWarning`  | *number*  | [optional] 途切れ監視のwarningのAlert発生閾値 (分)。                                                                 |
 | `missingDurationCritical` | *number*  | [optional] 途切れ監視のcriticalのAlert発生閾値 (分)。                                                                |
@@ -426,8 +426,8 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
 | `requestBody`                     | *string*   | [optional] リクエスト時のメッセージボディ |
 | `followRedirect` | *boolean* | [optional] リダイレクト先のレスポンスを結果として評価する。このフィールドを省略するとレスポンスに含まれるリダイレクト先を追跡しません。 |
 
-応答時間の監視を行うには `responseTimeWarning`, `responseTimeCritical`, `responseTimeDuration` の全てを指定する必要があります。
-証明書有効期限の監視を行うには `certificationExpirationWarning`, `certificationExpirationCritical` の両方を指定する必要があります。
+応答時間の監視を行うには `responseTimeWarning` と `responseTimeCritical` の両方またはいずれか一方と `responseTimeDuration` を指定する必要があります。
+証明書有効期限の監視を行うには `certificationExpirationWarning` と `certificationExpirationCritical` の両方またはいずれか一方を指定する必要があります。
 
 ##### 入力例
 
@@ -532,8 +532,8 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
 | `memo`          | *string*   | [optional] 監視ルールのメモ。 |
 | `expression`    | *string*   | 監視対象の式。グラフの系列が1本になるもののみ有効。 |
 | `operator`      | *string*   | 指定した数値より大きいか小さいかというアラート条件を指定。`">"` または `"<"`。左辺が観測値で右辺が設定値となります。|
-| `warning`       | *number*   | warningのAlert発生の閾値。 |
-| `critical`      | *number*   | criticalのAlert発生の閾値。 |
+| `warning`       | *number*   | [optional] warningのAlert発生の閾値。 |
+| `critical`      | *number*   | [optional] criticalのAlert発生の閾値。 |
 | `notificationInterval` | *number* | [optional] 通知の再送設定をするときの再送間隔 (分)。このフィールドを省略すると通知は再送されません。 |
 | `isMute`        | *boolean*       | [optional] 監視がミュート状態か否か [*3](#mute) |
 
@@ -619,12 +619,12 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
 | `name`          | *string*   | 監視一覧などで参照できる任意の名称。  |
 | `memo`          | *string*   | [optional] 監視ルールのメモ。 |
 | `scopes`        | *array[string]* | 監視対象のサービス名とロール詳細名。[*2](#service-name)  |
-| `warningSensitivity`       | *string*   | warningのAlert発生の閾値。`insensitive`、`normal`、`sensitive`のいずれか。 |
-| `criticalSensitivity`       | *string*   | criticalのAlert発生の閾値。`insensitive`、`normal`、`sensitive`のいずれか。 |
-| `maxCheckAttempts`     | *number* | [optional] 何回連続で Warning/Critical になったらアラートを発生させるか。デフォルトは3 (1~10)です。 |
-| `trainingPeriodFrom`     | *number* | [optional] 再学習させる際に起点となる時刻(epoch秒)。 |
-| `notificationInterval` | *number* | [optional] 通知の再送設定をするときの再送間隔 (分)。このフィールドを省略すると通知は再送されません。 |
-| `isMute`        | *boolean*       | [optional] 監視がミュート状態か否か |
+| `warningSensitivity`   | *string*  | [optional] warningのAlert発生の閾値。`insensitive`、`normal`、`sensitive`のいずれか。 |
+| `criticalSensitivity`  | *string*  | [optional] criticalのAlert発生の閾値。`insensitive`、`normal`、`sensitive`のいずれか。 |
+| `maxCheckAttempts`     | *number*  | [optional] 何回連続で Warning/Critical になったらアラートを発生させるか。デフォルトは3 (1~10)です。 |
+| `trainingPeriodFrom`   | *number*  | [optional] 再学習させる際に起点となる時刻(epoch秒)。 |
+| `notificationInterval` | *number*  | [optional] 通知の再送設定をするときの再送間隔 (分)。このフィールドを省略すると通知は再送されません。 |
+| `isMute`               | *boolean* | [optional] 監視がミュート状態か否か |
 
 ##### 入力例
 
@@ -690,6 +690,10 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
     <tr>
       <td>400</td>
       <td><code>warningSensitivity</code>または<code>criticalSensitivity</code>に <code>insensitive</code> / <code>normal</code> / <code>sensitive</code> 以外の値が指定されたとき</td>
+    </tr>
+    <tr>
+      <td>400</td>
+      <td><code>warningSensitivity</code>と<code>criticalSensitivity</code>の両方が未指定の時</td>
     </tr>
     <tr>
       <td>400</td>
@@ -853,7 +857,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
 
 - 通知の再送設定（`notificationInterval`）がされているアラート
 
-    `alertStatusOnGone` の変更後に通知の再送が発生した場合にのみ、そのタイミングで新しいアラートステータスに変更されます。  
+    `alertStatusOnGone` の変更後に通知の再送が発生した場合にのみ、そのタイミングで新しいアラートステータスに変更されます。
 
 - 通知の再送設定がされていないアラート
 


### PR DESCRIPTION
As announced in the link below back in 2018, we can create metric monitors with either one of warning or critical thresholds. I fixed the API documents to mark them to be optional.
- [Fix monitor API documents to mark thresholds to be optional.](https://mackerel.io/blog/entry/weekly/20180226)

BTW, we can create metric monitors with no thresholds via API, but not from web UI. The API lacks in validations.