### PR TITLE
Fix typos in API documents

### DIFF
--- a/content/api-docs/entry/alerts.md
+++ b/content/api-docs/entry/alerts.md
@@ -60,7 +60,7 @@ Alerts will be returned in chronological order of when they were generated from 
 | `monitorId`  | *string* | the ID of the monitor that generated the alert |
 | `type`  | *string* | the type of the monitor: connectivity (`"connectivity"`), host metric (`"host"`), service metric (`"service"`), external monitor (`"external"`), check monitor (`"check"`), expression monitor (`"expression"`), or anomaly detection for roles (`"anomalyDetection"`) |
 | `hostId`  | *string* | [optional] the associated host ID. only exists when the type of the monitor is either `"connectivity"`, `"host"`, `"check"`, or `"anomalyDetection"` |
-| `value`  | *number* | [optional] the value of the monitoring target. only exists when the type of the monitor is `"host"`, or `"service"` or when there is a reponse time configuration in `"external"` |
+| `value`  | *number* | [optional] the value of the monitoring target. only exists when the type of the monitor is `"host"`, or `"service"` or when there is a response time configuration in `"external"` |
 | `message`  | *string* | [optional] the monitoring target's message. only exists when the type of the monitor is either `"check"` or `"external"` |
 | `reason`  | *string* | [optional] the reason the alert closed. does not exist if the alert is unresolved. |
 | `openedAt`  | *number* | the timestamp of when the alert was generated (Unix time) |

--- a/content/api-docs/entry/aws-integration.md
+++ b/content/api-docs/entry/aws-integration.md
@@ -586,4 +586,8 @@ Here is a list of the AWS services and their corresponding identifiers (ID) used
 | `Firehose`      | Amazon Kinesis Data Firehose     |
 | `Batch`         | AWS Batch                        |
 | `WAF`           | AWS WAF                          |
-| `Billing`       | Billing                          |
+| `Billing`       | AWS Billing                      |
+| `Route 53`      | Amazon Route 53                  |
+| `Connect`       | Amazon Connect                   |
+| `DocDB`         | Amazon DocumentDB                |
+| `CodeBuild`     | AWS CodeBuild                    |

--- a/content/api-docs/entry/aws-integration.md
+++ b/content/api-docs/entry/aws-integration.md
@@ -471,7 +471,7 @@ The format is the same as the object <i>`<aws_integration>`</i> in the <a href="
 
 Returns a generated external ID.
 
-Once issued, the external ID can be reused as long as it is within the same organization, unless all AWS Integration settings configured with ths external ID are deleted.
+Once issued, the external ID can be reused as long as it is within the same organization, unless all AWS Integration settings configured with the external ID are deleted.
 
 ``` json
 {

--- a/content/api-docs/entry/check-monitoring.md
+++ b/content/api-docs/entry/check-monitoring.md
@@ -17,7 +17,7 @@ This will transmit a monitoring check report to Mackerel. Monitoring reports are
 The implementation described in [Adding monitors for script checks](https://mackerel.io/docs/entry/custom-checks) is used. The agent will periodically transmit the list of configured monitoring checks to the [Update Host Information](/api-docs/entry/hosts#update-information) API and any monitoring checks not included in that list and those which do not have any open alerts will be deleted from Mackerel at that time.
 Posts will be ignored in the following cases:
 
-- When the time of monitoring time preceeds the time of posting by 6 hours or more
+- When the time of monitoring time proceeds the time of posting by 6 hours or more
 - When a monitoring time has already been posted with the same name / host
 
 

--- a/content/api-docs/entry/dashboards.md
+++ b/content/api-docs/entry/dashboards.md
@@ -269,7 +269,7 @@ Objects representing widgets have the following formats for the differing types.
 | ---------- | -------- | --------------------------------------- |
 | `type`     | *string* | fixed character string `"alertStatus"`                 |
 | `title`    | *string* | the title of the widget                  |
-| `roleFullname` | *string*  | the service name and role name linked by `:`<br /> However, if the relavent role or service has been deleted when the dashboard is retrieved, `roleFullname` will be set as `null`. |
+| `roleFullname` | *string*  | the service name and role name linked by `:`<br /> However, if the relevant role or service has been deleted when the dashboard is retrieved, `roleFullname` will be set as `null`. |
 | `layout`   | *object* | [object representing the layout](#layout) |
 
 <h3 id="graph">Graphs</h3>

--- a/content/api-docs/entry/dashboards.md
+++ b/content/api-docs/entry/dashboards.md
@@ -242,7 +242,7 @@ Objects representing widgets have the following formats for the differing types.
 | `graph`  | *object* | [object representing a graph](#graph)                            |
 | `range`  | *object* | [optional] [object representing the graph display range](#graph-range) |
 | `valueRange` | *object* | [optional] [object representing the value range of vertical axis](#graph-value-range) |
-| `referenceLines` | *object* | [optional] [object representing the reference line](#reference-line). If you want to remove the reference line setting, specify an empty array.<br /> If reference line is not set when get dashboards, an empty array is returned. Cannot specify more than one element in an array.|
+| `referenceLines` | *array[object]* | [optional] array of [objects representing the reference line](#reference-line). If you want to remove the reference line setting, specify an empty array.<br /> If reference line is not set when get dashboards, an empty array is returned. Cannot specify more than one element in an array.|
 | `layout` | *object* | [object representing the layout](#layout)                       |
 
 ### Value widget

--- a/content/api-docs/entry/downtimes.md
+++ b/content/api-docs/entry/downtimes.md
@@ -37,11 +37,11 @@ Objects that hold the following keys:
 | `memo` | *string* | [optional] notes for the downtime |
 | `start` | *number* | the starting time(in epoch seconds) |
 | `duration` | *number* | the duration of downtime (in minutes) |
-| `recurrence` | *recurrence* | [optional] configuration for repeating occurences |
+| `recurrence` | *recurrence* | [optional] configuration for repeating occurrences |
 | `serviceScopes` | *array[string]* | [optional] scope of target services. service name array[*](#service-name-and-role-fullname) |
-| `serviceExcludeScopes` | *array[string]* | [optional] scope of exluded services. service name array[*](#service-name-and-role-fullname) |
+| `serviceExcludeScopes` | *array[string]* | [optional] scope of excluded services. service name array[*](#service-name-and-role-fullname) |
 | `roleScopes` | *array[string]* | [optional] scope of target roles. role fullname array[*](#service-name-and-role-fullname) |
-| `roleExcludeScopes` | *array[string]* | [optional] scope of exluded roles. role fullname array[*](#service-name-and-role-fullname) |
+| `roleExcludeScopes` | *array[string]* | [optional] scope of excluded roles. role fullname array[*](#service-name-and-role-fullname) |
 | `monitorScopes` | *array[string]* | [optional] scope of target monitor configurations. `<monitor id>` array |
 | `monitorExcludeScopes` | *array[string]* | [optional] scope of excluded monitor configurations. `<monitor id>` array |
 

--- a/content/api-docs/entry/host-metrics.md
+++ b/content/api-docs/entry/host-metrics.md
@@ -270,7 +270,7 @@ metric: an object that contains the following keys.
   {
       "name" : "custom.cpu.foo",
       "displayName": "CPU",
-      "unit":"percentage",
+      "unit": "percentage",
       "metrics": [
          { "name": "custom.cpu.foo.user", "displayName": "CPU user", "isStacked": true },
          { "name": "custom.cpu.foo.idle", "displayName": "CPU idle", "isStacked": true },
@@ -280,7 +280,7 @@ metric: an object that contains the following keys.
   {
       "name" : "custom.wild.#",
       "displayName": "wildcard",
-      "unit":"float",
+      "unit": "float",
       "metrics": [
          { "name": "custom.wild.#.foo", "displayName": "wild foo" },
          { "name": "custom.wild.#.bar", "displayName": "wild bar" },

--- a/content/api-docs/entry/host-metrics.md
+++ b/content/api-docs/entry/host-metrics.md
@@ -52,7 +52,7 @@ If old values are being transmitted to the API, the values on the Mackerel inter
 
 ```json
 {
-  "sucess": true
+  "success": true
 }
 ```
 

--- a/content/api-docs/entry/hosts.md
+++ b/content/api-docs/entry/hosts.md
@@ -734,7 +734,7 @@ Detailed information that accompanies the monitoring status. Currently only avai
 | KEY | TYPE | DESCRIPTION |
 | --- | --- | --- |
 | `type` | *string* | the type of detailed information. check monitoring is always `check` |
-| `message` | *string* | auxillary text such as command output results |
+| `message` | *string* | auxiliary text such as command output results |
 | `memo` | *string* | [optional] notes configured for check monitoring |
 
 #### Error

--- a/content/api-docs/entry/hosts.md
+++ b/content/api-docs/entry/hosts.md
@@ -725,9 +725,9 @@ Retrieves the monitor associated with the host and its status (monitoring status
 | --- | --- | --- |
 | `monitorId`  | *string* | monitor ID |
 | `status` | *string* | alert status. either `"OK"`, `"CRITICAL"`, `"WARNING"`, or `"UNKNOWN"` |
-| `detail` | *string* | [optional] detailed information[*6](#list-detail)|
+| `detail` | *object* | [optional] detailed information[*6](#monitored-status-detail)|
 
-<h4 id="list-detail" class="annotation">*6 detail</h4>
+<h4 id="monitored-status-detail" class="annotation">*6 detail</h4>
 
 Detailed information that accompanies the monitoring status. Currently only available for monitoring statuses of check monitoring.
 

--- a/content/api-docs/entry/monitors.md
+++ b/content/api-docs/entry/monitors.md
@@ -451,7 +451,7 @@ In order to monitor the certification expiration date, it’s necessary to speci
   "certificationExpirationWarning": 90,
   "certificationExpirationCritical": 30,
   "isMute": false,
-  "headers": [{"name":"Cache-Control", "value":"no-cache"}]
+  "headers": [{"name": "Cache-Control", "value": "no-cache"}]
 }
 ```
 
@@ -477,7 +477,7 @@ In order to monitor the certification expiration date, it’s necessary to speci
   "certificationLimitWarning": 90,
   "certificationLimitCritical": 30,
   "isMute": false,
-  "headers": [{"name":"Cache-Control", "value":"no-cache"}]
+  "headers": [{"name": "Cache-Control", "value": "no-cache"}]
 }
 ```
 
@@ -680,7 +680,7 @@ In order to monitor the certification expiration date, it’s necessary to speci
       "memo": "Monitors example.com",
       "url": "http://www.example.com",
       "service": "Hatena-Blog",
-      "headers": [{"name":"Cache-Control", "value":"no-cache"}],
+      "headers": [{"name": "Cache-Control", "value": "no-cache"}],
       "maxCheckAttempts": 1
     },
     {

--- a/content/api-docs/entry/monitors.md
+++ b/content/api-docs/entry/monitors.md
@@ -793,7 +793,7 @@ In order to monitor the certification expiration date, it’s necessary to speci
     </tr>
     <tr>
       <td>400</td>
-      <td>when a future vaule is specified for <code>trainingPeriodFrom</code></td>
+      <td>when a future value is specified for <code>trainingPeriodFrom</code></td>
     </tr>
     <tr>
       <td>403</td>

--- a/content/ja/api-docs/entry/aws-integration.md
+++ b/content/ja/api-docs/entry/aws-integration.md
@@ -586,4 +586,8 @@ Mackerel で用いられる識別子（ID）とそれに対応するAWSサービ
 | `Firehose`      | Amazon Kinesis Data Firehose     |
 | `Batch`         | AWS Batch                        |
 | `WAF`           | AWS WAF                          |
-| `Billing`       | Billing                          |
+| `Billing`       | AWS Billing                      |
+| `Route 53`      | Amazon Route 53                  |
+| `Connect`       | Amazon Connect                   |
+| `DocDB`         | Amazon DocumentDB                |
+| `CodeBuild`     | AWS CodeBuild                    |

--- a/content/ja/api-docs/entry/dashboards.md
+++ b/content/ja/api-docs/entry/dashboards.md
@@ -242,7 +242,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
 | `graph`  | *object* | [グラフを表すオブジェクト](#graph)                            |
 | `range`  | *object* | [optional] [グラフの表示期間を表すオブジェクト](#graph-range) |
 | `valueRange` | *object* | [optional] [グラフの縦軸固定を表すオブジェクト](#graph-value-range) |
-| `referenceLines` | *array[object]* | [optional] [補助線を表すオブジェクト](#reference-line)。補助線の設定を削除したい場合には、空の配列を指定してください。<br />ダッシュボードの取得時に補助線が未設定の場合、空の配列が返されます。配列に2つ以上の要素を指定できません。 |
+| `referenceLines` | *array[object]* | [optional] [補助線を表すオブジェクト](#reference-line)の配列。補助線の設定を削除したい場合には、空の配列を指定してください。<br />ダッシュボードの取得時に補助線が未設定の場合、空の配列が返されます。配列に2つ以上の要素を指定できません。 |
 | `layout` | *object* | [レイアウトを表すオブジェクト](#layout)                       |
 
 ### 数値ウィジェット
@@ -253,7 +253,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
 | `metric`       | *object* | [メトリックを表すオブジェクト](#metric)    |
 | `fractionSize` | *number* | [optional] 表示する小数点以下の桁数 (0–16) |
 | `suffix`       | *string* | [optional] 数値の後に表示する単位 |
-| `formatRules` | *array[object]* | [optional] [フォーマットルールを表すオブジェクト](#format-rule)。フォーマットルールの設定を削除したい場合には、空の配列を指定してください。<br />ダッシュボードの取得時にフォーマットルールが未設定の場合、空の配列が返されます。配列に2つ以上の要素を指定できません。 |
+| `formatRules`  | *array[object]* | [optional] [フォーマットルールを表すオブジェクト](#format-rule)の配列。フォーマットルールの設定を削除したい場合には、空の配列を指定してください。<br />ダッシュボードの取得時にフォーマットルールが未設定の場合、空の配列が返されます。配列に2つ以上の要素を指定できません。 |
 | `layout`       | *object* | [レイアウトを表すオブジェクト](#layout)    
 
 ### Markdownウィジェット

--- a/content/ja/api-docs/entry/host-metrics.md
+++ b/content/ja/api-docs/entry/host-metrics.md
@@ -269,7 +269,7 @@ APIに対して過去の値を送信した場合、Mackerel上の値は上書き
   {
       "name" : "custom.cpu.foo",
       "displayName": "CPU",
-      "unit":"percentage",
+      "unit": "percentage",
       "metrics": [
          { "name": "custom.cpu.foo.user", "displayName": "CPU user", "isStacked": true },
          { "name": "custom.cpu.foo.idle", "displayName": "CPU idle", "isStacked": true },
@@ -279,7 +279,7 @@ APIに対して過去の値を送信した場合、Mackerel上の値は上書き
   {
       "name" : "custom.wild.#",
       "displayName": "wildcard",
-      "unit":"float",
+      "unit": "float",
       "metrics": [
          { "name": "custom.wild.#.foo", "displayName": "wild foo" },
          { "name": "custom.wild.#.bar", "displayName": "wild bar" },

--- a/content/ja/api-docs/entry/host-metrics.md
+++ b/content/ja/api-docs/entry/host-metrics.md
@@ -51,7 +51,7 @@ APIに対して過去の値を送信した場合、Mackerel上の値は上書き
 
 ```json
 {
-  "sucess": true
+  "success": true
 }
 ```
 

--- a/content/ja/api-docs/entry/hosts.md
+++ b/content/ja/api-docs/entry/hosts.md
@@ -722,9 +722,9 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
 | --- | --- | --- |
 | `monitorId`  | *string* | 監視ルールのID |
 | `status` | *string* | アラートステータス。`"OK"`、 `"CRITICAL"`、 `"WARNING"`、 `"UNKNOWN"` のいずれかになります。 |
-| `detail` | *string* | [optional] 詳細情報[*6](#list-detail)|
+| `detail` | *object* | [optional] 詳細情報[*6](#monitored-status-detail)|
 
-<h4 id="list-detail" class="annotation">*6 detail</h4>
+<h4 id="monitored-status-detail" class="annotation">*6 detail</h4>
 
 監視ステータスに付随する詳細情報です。現在はチェック監視の監視ステータスにのみ付加されます。
 

--- a/content/ja/api-docs/entry/monitors.md
+++ b/content/ja/api-docs/entry/monitors.md
@@ -448,7 +448,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
   "certificationExpirationWarning": 90,
   "certificationExpirationCritical": 30,
   "isMute": false,
-  "headers": [{"name":"Cache-Control", "value":"no-cache"}]
+  "headers": [{"name": "Cache-Control", "value": "no-cache"}]
 }
 ```
 
@@ -474,7 +474,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
   "certificationLimitWarning": 90,
   "certificationLimitCritical": 30,
   "isMute": false,
-  "headers": [{"name":"Cache-Control", "value":"no-cache"}]
+  "headers": [{"name": "Cache-Control", "value": "no-cache"}]
 }
 ```
 
@@ -776,7 +776,7 @@ EditURL: https://blog.hatena.ne.jp/mackerelio/mackerelio-api-jp.hatenablog.macke
       "memo": "Monitors example.com",
       "url": "http://www.example.com",
       "service": "Hatena-Blog",
-      "headers": [{"name":"Cache-Control", "value":"no-cache"}],
+      "headers": [{"name": "Cache-Control", "value": "no-cache"}],
       "maxCheckAttempts": 1
     },
     {


### PR DESCRIPTION
Let me fix some typos in the API documents.